### PR TITLE
feat : 회원가입 api 생성

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -25,13 +25,17 @@ public enum BaseResponseStatus {
     INVALID_USER_JWT(false,HttpStatus.FORBIDDEN.value(),"권한이 없는 유저의 접근입니다."),
     RESPONSE_ERROR(false, HttpStatus.NOT_FOUND.value(), "값을 불러오는데 실패하였습니다."),
 
-    // users
-    USERS_EMPTY_USER_ID(false, HttpStatus.BAD_REQUEST.value(), "유저 아이디 값을 확인해주세요."),
-
     // [POST] /users
+    USERS_EMPTY_USER_ID(false, HttpStatus.BAD_REQUEST.value(), "유저 아이디 값을 확인해주세요."),
+    POST_USERS_INVALID_ID(false, HttpStatus.BAD_REQUEST.value(), "아이디 형식을 확인해주세요."),
+    POST_USERS_INVALID_PW(false, HttpStatus.BAD_REQUEST.value(), "비밀번호 형식을 확인해주세요."),
+    POST_USERS_EMPTY_NAME(false, HttpStatus.BAD_REQUEST.value(), "이름을 입력해주세요."),
     POST_USERS_EMPTY_EMAIL(false, HttpStatus.BAD_REQUEST.value(), "이메일을 입력해주세요."),
     POST_USERS_INVALID_EMAIL(false, HttpStatus.BAD_REQUEST.value(), "이메일 형식을 확인해주세요."),
     POST_USERS_EXISTS_EMAIL(false,HttpStatus.BAD_REQUEST.value(),"중복된 이메일입니다."),
+    POST_USERS_INVALID_BIRTH(false, HttpStatus.BAD_REQUEST.value(), "생년월일 형식을 확인해주세요."),
+    POST_USERS_EMPTY_NICKNAME(false, HttpStatus.BAD_REQUEST.value(), "닉네임을 입력해주세요."),
+    POST_USERS_INVALID_NICKNAME(false, HttpStatus.BAD_REQUEST.value(), "닉네임 형식을 확인해주세요."),
     FAILED_TO_LOGIN(false,HttpStatus.NOT_FOUND.value(),"없는 아이디거나 비밀번호가 틀렸습니다."),
 
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -1,0 +1,65 @@
+package com.spring.familymoments.domain.user;
+
+import com.spring.familymoments.config.BaseResponse;
+import com.spring.familymoments.domain.user.model.PostUserReq;
+import com.spring.familymoments.domain.user.model.PostUserRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.spring.familymoments.config.BaseResponseStatus.*;
+import static com.spring.familymoments.utils.ValidationRegex.*;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    /**
+     * 회원 가입 API
+     * [POST] /users/sign-up
+     * @return BaseResponse<UserSaveRequestDto>
+     */
+    @ResponseBody
+    @PostMapping("/users/sign-up")
+    public BaseResponse<PostUserRes> createUser(@RequestBody PostUserReq postUserReq) {
+        //아이디
+        if(postUserReq.getId() == null) {
+            return new BaseResponse<>(USERS_EMPTY_USER_ID);
+        }
+        if(!isRegexId(postUserReq.getId())) {
+            return new BaseResponse<>(POST_USERS_INVALID_ID);
+        }
+        //비밀번호
+        if(!isRegexPw(postUserReq.getPassword())) {
+            return new BaseResponse<>(POST_USERS_INVALID_PW);
+        }
+        //이름
+        if(postUserReq.getName() == null) {
+            return new BaseResponse<>(POST_USERS_EMPTY_NAME);
+        }
+        //이메일
+        if(postUserReq.getEmail() == null) {
+            return new BaseResponse<>(POST_USERS_EMPTY_EMAIL);
+        }
+        if(!isRegexEmail(postUserReq.getEmail())) {
+            return new BaseResponse<>(POST_USERS_INVALID_EMAIL);
+        }
+        //생년월일
+        if(!isRegexBirth(postUserReq.getBirthDate())) {
+            return new BaseResponse<>(POST_USERS_INVALID_BIRTH);
+        }
+        //닉네임
+        if(postUserReq.getNickname() == null) {
+            return new BaseResponse<>(POST_USERS_EMPTY_NICKNAME);
+        }
+        if(!isRegexNickName(postUserReq.getNickname())) {
+            return new BaseResponse<>(POST_USERS_INVALID_NICKNAME);
+        }
+
+        PostUserRes postUserRes = userService.createUser(postUserReq);
+        return new BaseResponse<>(postUserRes);
+    }
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
@@ -1,0 +1,8 @@
+package com.spring.familymoments.domain.user;
+
+import com.spring.familymoments.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -1,0 +1,19 @@
+package com.spring.familymoments.domain.user;
+
+import com.spring.familymoments.domain.user.model.PostUserReq;
+import com.spring.familymoments.domain.user.model.PostUserRes;
+import com.spring.familymoments.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public PostUserRes createUser(PostUserReq postUserReq) {
+        // TODO: 비밀번호 암호화
+        User saveUser = userRepository.save(postUserReq.toEntity());
+        //return new PostUserRes(saveUser.getUserId());
+        return new PostUserRes(saveUser.getId(), saveUser.getPassword());
+    }
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/entity/User.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/entity/User.java
@@ -41,8 +41,8 @@ public class User extends BaseTime {
     @Column(nullable = false, length = 20)
     private String nickname;
 
-    @Column(nullable = false)
-    private LocalDateTime birthDate;
+    @Column(nullable = false, length = 10)
+    private String birthDate;
 
     @Column(columnDefinition = "TEXT")
     private String profileImg;

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostUserReq.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostUserReq.java
@@ -1,0 +1,34 @@
+package com.spring.familymoments.domain.user.model;
+
+import com.spring.familymoments.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostUserReq {
+    private String id;
+    private String password;
+    private String name;
+    private String email;
+    private String birthDate;
+    private String nickname;
+    private String profileImg;
+
+    public User toEntity() {
+        return User.builder()
+                .id(this.id)
+                .password(this.password)
+                .name(this.name)
+                .email(this.email)
+                .birthDate(this.birthDate)
+                .nickname(this.nickname)
+                .profileImg(this.profileImg)
+                .build();
+    }
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostUserRes.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostUserRes.java
@@ -1,0 +1,20 @@
+package com.spring.familymoments.domain.user.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostUserRes {
+    private String id;
+    private String pw;
+
+    //private String jwt;
+    /*public PostUserRes(Long id) {
+        this.id = id;
+    }*/
+}

--- a/family-moments/src/main/java/com/spring/familymoments/utils/ValidationRegex.java
+++ b/family-moments/src/main/java/com/spring/familymoments/utils/ValidationRegex.java
@@ -1,0 +1,37 @@
+package com.spring.familymoments.utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ValidationRegex {
+    public static boolean isRegexId(String target) {
+        String regex = "^[A-za-z0-9]{6,12}$";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(target);
+        return matcher.find();
+    }
+    public static boolean isRegexEmail(String target) {
+        String regex = "^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,6}$";
+        Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(target);
+        return matcher.find();
+    }
+    public static boolean isRegexPw(String target) {
+        String regex = "^[A-za-z0-9]{8,12}$";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(target);
+        return matcher.find();
+    }
+    public static boolean isRegexNickName(String target) {
+        String regex = "^[가-힣a-zA-Z0-9]{3,8}$";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(target);
+        return matcher.find();
+    }
+    public static boolean isRegexBirth(String target) {
+        String regex = "^[0-9]{8}$";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(target);
+        return matcher.find();
+    }
+}

--- a/family-moments/src/test/java/com/spring/familymoments/UserControllerTest.java
+++ b/family-moments/src/test/java/com/spring/familymoments/UserControllerTest.java
@@ -1,0 +1,51 @@
+package com.spring.familymoments;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spring.familymoments.domain.user.UserController;
+import com.spring.familymoments.domain.user.UserService;
+import com.spring.familymoments.domain.user.model.PostUserReq;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class UserControllerTest {
+    MockMvc mockMvc;
+    @InjectMocks
+    UserController userController;
+
+    @Mock
+    UserService userService;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void beforeEach() {
+        mockMvc = MockMvcBuilders.standaloneSetup(userController).build();
+    }
+
+    @Test
+    @DisplayName("유저 생성")
+    public void saveUserTest() throws Exception {
+        PostUserReq postUserReq = new PostUserReq(null, "spacewalk0", "정유영", "ju001217@naver.com", "20001217", "융입니다", "");
+        mockMvc.perform(post("/users/sign-up")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(postUserReq)))
+                        .andExpect(status().isOk())
+                        .andDo(print());
+        //verify(userService).createUser(postUserReq);
+    }
+}


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 회원가입 api 생성했습니다.
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
1. User. java
-  User entity birthdate 칼럼 LocalDate에서 String 자료형으로 변경했습니다. 
-  length는 10으로 잡았습니다.
2. BaseResponseStatus.java
- 예외 처리 코드 추가했습니다.

### 작업 내역

- 작업 내역 
1. familymoments/config/BaseResponseStatus.java
2. familymoments/domain/user/UserController.java
4. familymoments/domain/user/UserRepository.java
5. familymoments/domain/user/UserService.java
6. familymoments/domain/entity/User.java
7. familymoments/domain/model/PostUserReq.java
8. familymoments/domain/model/PostUserRes.java
9. familymoments/utils/ValidationRegex.java
10. familymoments/UserControllerTest.java

### 작업 후 기대 동작(스크린샷)

- 동작
- > 사용자가 회원가입 폼 요소들 중 아이디를 입력하지 않았을 때, 관련 동작 화면 
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/729df4ef-d1de-4f82-92fd-8414822fe166)

### PR 특이 사항

- 특이 사항
- 이후에 벤티님이 봐주실 예정입니다.

### Issue Number 

close: #1

### 어떤 부분에 리뷰어가 집중하면 좋을까요?

- PostUserRes에 패스워드의 값을 return 해서 보안 상 좋지 않고 
- 이후에 로그인 구현할 때 다시 수정할 부분입니다. 
- 벤티 님이 <jwt 작업> 함께 도와주실 예정입니다.
