### PR TITLE
feat: 가족정보 조회 / 가족 초대 및 승락 api

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/family-moments-BE2.iml" filepath="$PROJECT_DIR$/.idea/family-moments-BE2.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/family-moments-server.main.iml" filepath="$PROJECT_DIR$/.idea/modules/family-moments-server.main.iml" />
     </modules>
   </component>
 </project>

--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponse.java
@@ -33,4 +33,10 @@ public class BaseResponse<T> {
         this.message = status.getMessage();
         this.code = status.getCode();
     }
+
+    public BaseResponse(Boolean isSuccess, String message, int code) {
+        this.isSuccess = isSuccess;
+        this.message = message;
+        this.code = code;
+    }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -39,7 +39,9 @@ public enum BaseResponseStatus {
     POST_USERS_EMPTY_NICKNAME(false, HttpStatus.BAD_REQUEST.value(), "닉네임을 입력해주세요."),
     POST_USERS_INVALID_NICKNAME(false, HttpStatus.BAD_REQUEST.value(), "닉네임 형식을 확인해주세요."),
     FAILED_TO_LOGIN(false,HttpStatus.NOT_FOUND.value(),"없는 아이디거나 비밀번호가 틀렸습니다."),
+
     FIND_FAIL_FAMILY(false, HttpStatus.NOT_FOUND.value(), "존재하지 않는 가족입니다."),
+    FAILED_INVITE_USER_FAMILY(false, HttpStatus.CONFLICT.value(), "이미 가족에 가입된 회원입니다."),
 
 
     /**

--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -39,7 +39,7 @@ public enum BaseResponseStatus {
     POST_USERS_EMPTY_NICKNAME(false, HttpStatus.BAD_REQUEST.value(), "닉네임을 입력해주세요."),
     POST_USERS_INVALID_NICKNAME(false, HttpStatus.BAD_REQUEST.value(), "닉네임 형식을 확인해주세요."),
     FAILED_TO_LOGIN(false,HttpStatus.NOT_FOUND.value(),"없는 아이디거나 비밀번호가 틀렸습니다."),
-
+    FIND_FAIL_FAMILY(false, HttpStatus.NOT_FOUND.value(), "존재하지 않는 가족입니다."),
 
 
     /**

--- a/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
@@ -1,0 +1,14 @@
+package com.spring.familymoments.domain.common;
+
+import com.spring.familymoments.domain.common.entity.UserFamily;
+import com.spring.familymoments.domain.family.entity.Family;
+import com.spring.familymoments.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserFamilyRepository extends JpaRepository<UserFamily, Long> {
+
+    Optional<UserFamily> findByUserId(Optional<User> user);
+    Optional<UserFamily> findByUserIdAndFamilyId(User userId, Family familyId);
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/common/entity/UserFamily.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/common/entity/UserFamily.java
@@ -15,7 +15,7 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor(force = true)
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 @DynamicInsert
 @DynamicUpdate
 public class UserFamily extends BaseTime {
@@ -37,7 +37,7 @@ public class UserFamily extends BaseTime {
     @Column(name = "status", nullable = false, length = 10)
     protected Status status = Status.DEACCEPT;
 
-    private enum Status {
+    public enum Status {
         ACTIVE, INACTIVE, DEACCEPT, REJECT;
     }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
@@ -2,13 +2,21 @@ package com.spring.familymoments.domain.family;
 
 import com.spring.familymoments.config.BaseException;
 import com.spring.familymoments.config.BaseResponse;
+import com.spring.familymoments.domain.family.model.FamilyDto;
 import com.spring.familymoments.domain.family.model.PostFamilyReq;
 import com.spring.familymoments.domain.family.model.PostFamilyRes;
 import com.spring.familymoments.domain.user.UserService;
 import com.spring.familymoments.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.NoSuchElementException;
+
+import static com.spring.familymoments.config.BaseResponseStatus.FIND_FAIL_FAMILY;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,14 +26,47 @@ public class FamilyController {
     private final FamilyService familyService;
     private final UserService userService;
 
-    @ResponseBody
-    @PostMapping("/{userId}")
-    public BaseResponse<PostFamilyRes> createFamily(@PathVariable Long userId, @RequestBody PostFamilyReq postFamilyReq) throws BaseException {
-//        String uuid = jwtService.resolveToken();
-        System.out.println("여기는 가족 post");
-        User owner = userService.getUserMinjeong(userId);
+//    @ResponseBody
+//    @PostMapping("/{userId}")
+//    public BaseResponse<PostFamilyRes> createFamily(@PathVariable Long userId, @RequestBody PostFamilyReq postFamilyReq) throws BaseException {
+////        String uuid = jwtService.resolveToken();
+//        System.out.println("여기는 가족 post");
+//        User owner = userService.getUserMinjeong(userId);
+//
+//        PostFamilyRes postFamilyRes = familyService.createFamily(owner, postFamilyReq);
+//        return new BaseResponse<>(postFamilyRes);
+//    }
 
-        PostFamilyRes postFamilyRes = familyService.createFamily(owner, postFamilyReq);
-        return new BaseResponse<>(postFamilyRes);
+    /**
+     * 가족 정보 조회 API
+     * [GET] /familyId
+     * @return BaseResponse<FamilyDto>
+     */
+    @ResponseBody
+    @GetMapping("/{familyId}")
+    public BaseResponse<FamilyDto> getFamily(@PathVariable Long familyId) throws BaseException{
+        //return new BaseResponse<>(familyService.getFamily(familyId));
+        try {
+            FamilyDto familyDto = familyService.getFamily(familyId);
+            return new BaseResponse<>(familyDto);
+        } catch (NoSuchElementException e) {
+            return new BaseResponse<>(FIND_FAIL_FAMILY);
+        }
+    }
+
+    /**
+     * 초대코드로 가족 정보 조회 API
+     * [GET] /familyId
+     * @return BaseResponse<FamilyDto>
+     */
+    @GetMapping("/{inviteCode}/inviteCode")
+    public BaseResponse<FamilyDto> getFamilyByInviteCode(@PathVariable String inviteCode) throws BaseException{
+        //return new BaseResponse<>(familyService.getFamily(familyId));
+        try {
+            FamilyDto familyDto = familyService.getFamilyByInviteCode(inviteCode);
+            return new BaseResponse<>(familyDto);
+        } catch (NoSuchElementException e) {
+            return new BaseResponse<>(FIND_FAIL_FAMILY);
+        }
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
@@ -14,9 +14,10 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.persistence.EntityNotFoundException;
+import java.util.List;
 import java.util.NoSuchElementException;
 
-import static com.spring.familymoments.config.BaseResponseStatus.FIND_FAIL_FAMILY;
+import static com.spring.familymoments.config.BaseResponseStatus.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -56,7 +57,7 @@ public class FamilyController {
 
     /**
      * 초대코드로 가족 정보 조회 API
-     * [GET] /familyId
+     * [GET] /{inviteCode}/inviteCode
      * @return BaseResponse<FamilyDto>
      */
     @GetMapping("/{inviteCode}/inviteCode")
@@ -67,6 +68,40 @@ public class FamilyController {
             return new BaseResponse<>(familyDto);
         } catch (NoSuchElementException e) {
             return new BaseResponse<>(FIND_FAIL_FAMILY);
+        }
+    }
+
+    /**
+     * 초대 API
+     * [GET] /familyId
+     * @return BaseResponse<String>
+     */
+    @PostMapping("/{familyId}")
+    public BaseResponse<String> inviteUser(@PathVariable Long familyId,
+                                           @RequestParam List<Long> userIds) throws BaseException{
+        try {
+            familyService.inviteUser(userIds, familyId);
+            return new BaseResponse<>("초대 요청이 완료되었습니다.");
+        } catch (IllegalAccessException e) {
+            return new BaseResponse<>(false, e.getMessage(), HttpStatus.CONFLICT.value());
+        } catch (NoSuchElementException e){
+            return new BaseResponse<>(FIND_FAIL_USERNAME);
+        }
+    }
+
+    /**
+     * 초대 승락 API
+     * [GET] /{familyId}/users/{userId}/invite-accept
+     * @return BaseResponse<String>
+     */
+    @PatchMapping("/{familyId}/users/{userId}/invite-accept")
+    public BaseResponse<String> acceptFamily(@PathVariable Long familyId,
+                                             @PathVariable Long userId) throws BaseException{
+        try {
+            familyService.acceptFamily(userId, familyId);
+            return new BaseResponse<>("초대가 수락되었습니다.");
+        }catch (NoSuchElementException e){
+            return new BaseResponse<>(false, e.getMessage(), HttpStatus.NOT_FOUND.value());
         }
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
@@ -3,5 +3,11 @@ package com.spring.familymoments.domain.family;
 import com.spring.familymoments.domain.family.entity.Family;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FamilyRepository extends JpaRepository<Family, Long> {
+    Optional<Family> findById(Long aLong);
+
+    Optional<Family> findByInviteCode(String inviteCode);
+
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
@@ -1,13 +1,19 @@
 package com.spring.familymoments.domain.family;
 
 import com.spring.familymoments.domain.family.entity.Family;
+import com.spring.familymoments.domain.family.model.FamilyDto;
 import com.spring.familymoments.domain.family.model.PostFamilyReq;
 import com.spring.familymoments.domain.family.model.PostFamilyRes;
+import com.spring.familymoments.domain.user.UserService;
 import com.spring.familymoments.domain.user.entity.User;
+import com.sun.xml.bind.v2.TODO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +21,7 @@ import javax.transaction.Transactional;
 public class FamilyService {
 
     private final FamilyRepository familyRepository;
+    private final UserService userService;
 
     public PostFamilyRes createFamily(User owner, PostFamilyReq postFamilyReq) {
         Family family = Family.builder()
@@ -28,4 +35,40 @@ public class FamilyService {
 
         return new PostFamilyRes(saveFamily.getFamilyId(), owner.getNickname(), saveFamily.getInviteCode(), owner.getProfileImg(), saveFamily.getRepresentImg(), saveFamily.getCreatedAt());
     }
+
+
+    //특정 가족 정보 조회
+    public FamilyDto getFamily(Long id){
+        Optional<Family> family = familyRepository.findById(id);
+
+        if (family.isEmpty()) {
+            throw new NoSuchElementException("존재하지 않습니다");
+        }
+
+        return FamilyDto.builder()
+                .owner(family.get().getOwner().getNickname())
+                .familyName(family.get().getFamilyName())
+                .uploadCycle(family.get().getUploadCycle())
+                .inviteCode(family.get().getInviteCode())
+                .representImg(family.get().getRepresentImg())
+                .build();
+
+    }
+
+    public FamilyDto getFamilyByInviteCode(String inviteCode){
+        Optional<Family> family = familyRepository.findByInviteCode(inviteCode);
+
+        if (family.isEmpty()) {
+            throw new NoSuchElementException("존재하지 않습니다");
+        }
+
+        return FamilyDto.builder()
+                .owner(family.get().getOwner().getNickname())
+                .familyName(family.get().getFamilyName())
+                .uploadCycle(family.get().getUploadCycle())
+                .inviteCode(family.get().getInviteCode())
+                .representImg(family.get().getRepresentImg())
+                .build();
+    }
+
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
@@ -1,19 +1,26 @@
 package com.spring.familymoments.domain.family;
 
+import com.spring.familymoments.domain.common.UserFamilyRepository;
+import com.spring.familymoments.domain.common.entity.UserFamily;
 import com.spring.familymoments.domain.family.entity.Family;
 import com.spring.familymoments.domain.family.model.FamilyDto;
 import com.spring.familymoments.domain.family.model.PostFamilyReq;
 import com.spring.familymoments.domain.family.model.PostFamilyRes;
+import com.spring.familymoments.domain.user.UserRepository;
 import com.spring.familymoments.domain.user.UserService;
 import com.spring.familymoments.domain.user.entity.User;
 import com.sun.xml.bind.v2.TODO;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+
+import static com.spring.familymoments.domain.common.entity.UserFamily.Status.ACTIVE;
+import static com.spring.familymoments.domain.common.entity.UserFamily.Status.DEACCEPT;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +29,8 @@ public class FamilyService {
 
     private final FamilyRepository familyRepository;
     private final UserService userService;
+    private final UserFamilyRepository userFamilyRepository;
+    private final UserRepository userRepository;
 
     public PostFamilyRes createFamily(User owner, PostFamilyReq postFamilyReq) {
         Family family = Family.builder()
@@ -69,6 +78,66 @@ public class FamilyService {
                 .inviteCode(family.get().getInviteCode())
                 .representImg(family.get().getRepresentImg())
                 .build();
+
+    }
+
+    // 가족 초대
+    public void inviteUser(List<Long> userIdList, Long familyId) throws IllegalAccessException {
+        Optional<Family> familyOptional = familyRepository.findById(familyId);
+        // 1. 리스트의 유저들이 family에 가입했는지 확인
+        // 가입 -> 테이블에 존재&&상태 ACTIVE
+        if (familyOptional.isPresent()) {
+            Family family = familyOptional.get();
+
+            for (Long ids : userIdList) {
+                Optional<UserFamily> byUserId = userFamilyRepository.findByUserId(userRepository.findById(ids));
+
+                if (byUserId.isPresent() && byUserId.get().getStatus() == ACTIVE) {
+                    throw new IllegalAccessException("이미 가족에 가입된 회원입니다.");
+                }if(byUserId.isPresent() && byUserId.get().getStatus() == DEACCEPT && byUserId.get().getFamilyId() == family){
+                    throw new IllegalAccessException("이미 초대 요청을 보낸 회원입니다.");
+                } else {
+                    User user = userRepository.findById(ids)
+                            .orElseThrow(() -> new NoSuchElementException("유저를 찾을 수 없습니다."));
+
+                    UserFamily userFamily = UserFamily.builder()
+                            .familyId(family)
+                            .userId(user)
+                            .status(DEACCEPT).build();
+
+                    userFamilyRepository.save(userFamily);
+                }
+            }
+        } else {
+            throw new NoSuchElementException("가족을 찾을 수 없습니다.");
+        }
+    }
+
+    // 가족 초대 수락
+    public void acceptFamily(Long userId, Long familyId){
+        Optional<User> userOptional = userRepository.findById(userId);
+        Optional<Family> familyOptional = familyRepository.findById(familyId);
+
+        if (userOptional.isPresent() && familyOptional.isPresent()) {
+            User user = userOptional.get();
+            Family family = familyOptional.get();
+
+            Optional<UserFamily> userFamily = userFamilyRepository.findByUserIdAndFamilyId(user, family);
+
+            // 1. 매핑 테이블에서 userId와 familyId로 검색
+            if (userFamily.isPresent()) {
+                // 2. 상태 바꿔줌
+                UserFamily updatedUserFamily = userFamily.get().toBuilder()
+                        .status(ACTIVE)
+                        .build();
+
+                userFamilyRepository.save(updatedUserFamily);
+            } else {
+                throw new NoSuchElementException("존재하지 않는 초대 내역입니다.");
+            }
+        } else {
+            throw new NoSuchElementException("존재하지 않는 사용자 또는 가족입니다.");
+        }
     }
 
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/entity/Family.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/entity/Family.java
@@ -1,5 +1,6 @@
 package com.spring.familymoments.domain.family.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.spring.familymoments.domain.common.BaseEntity;
 import com.spring.familymoments.domain.user.entity.User;
 import lombok.*;
@@ -28,7 +29,7 @@ public class Family extends BaseEntity {
     private Long familyId;
 
     @NotBlank
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "owner", nullable = false)
     private User owner;
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/entity/Family.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/entity/Family.java
@@ -23,12 +23,10 @@ public class Family extends BaseEntity {
 
 
     @Id
-    @NotBlank
     @Column(name = "familyId", nullable = false, updatable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long familyId;
 
-    @NotBlank
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "owner", nullable = false)
     private User owner;

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/model/FamilyDto.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/model/FamilyDto.java
@@ -1,6 +1,7 @@
 package com.spring.familymoments.domain.family.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.spring.familymoments.domain.family.entity.Family;
 import com.spring.familymoments.domain.user.entity.User;
 import lombok.*;
 
@@ -15,4 +16,14 @@ public class FamilyDto {
     private int uploadCycle;
     private String inviteCode;
     private String representImg;
+
+//    public Family toEntity() {
+//        return Family.builder()
+//                .owner()
+//                .familyName(this.familyName)
+//                .uploadCycle(this.uploadCycle)
+//                .inviteCode(this.inviteCode)
+//                .representImg(this.representImg)
+//                .build();
+//    }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/model/FamilyDto.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/model/FamilyDto.java
@@ -1,0 +1,18 @@
+package com.spring.familymoments.domain.family.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.spring.familymoments.domain.user.entity.User;
+import lombok.*;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FamilyDto {
+    //@JsonIgnore
+    private String owner;
+    private String familyName;
+    private int uploadCycle;
+    private String inviteCode;
+    private String representImg;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/model/PostFamilyRes.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/model/PostFamilyRes.java
@@ -2,10 +2,7 @@ package com.spring.familymoments.domain.family.model;
 
 import com.spring.familymoments.domain.family.entity.Family;
 import com.spring.familymoments.domain.user.entity.User;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : id, 초대코드로 가족 정보 조회, 가족 초대 api, 초대 승락 api
- [ ] 버그 수정 :
- [x] 리펙토링 : UserFamil enum `private` -> `public` / family 엔티티의 @NotBlank삭제(String 타입에서만 사용 가능)
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유


### 작업 내역

- familyId로 가족정보 조회
- 초대 코드로 가족 정보 조회
- 가족 초대 api
- 초대 승락 api

### 작업 후 기대 동작(스크린샷)

- 동작 
![image](https://github.com/familymoments/family-moments-BE/assets/68217805/4e83ef8c-6a39-4b95-8ec6-614a66be4477)
![image](https://github.com/familymoments/family-moments-BE/assets/68217805/95ec4705-951e-433a-90b0-b640a38f6442)


### PR 특이 사항

- 특이 사항

### Issue Number 

close: #8

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
controller의 createFamily 부분 주석처리하고 작업했습니다!
