### PR TITLE
feat: 아이디 중복확인 api

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -6,6 +6,7 @@ import com.spring.familymoments.domain.user.model.PostUserReq;
 import com.spring.familymoments.domain.user.model.PostUserRes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -21,7 +22,7 @@ public class UserController {
     /**
      * 회원 가입 API
      * [POST] /users/sign-up
-     * @return BaseResponse<UserSaveRequestDto>
+     * @return BaseResponse<PostUserRes>
      */
     @ResponseBody
     @PostMapping("/users/sign-up")
@@ -64,5 +65,15 @@ public class UserController {
         PostUserRes postUserRes = userService.createUser(postUserReq, profileImage);
         log.info("[createUser]: PostUserRes 생성 완료!");
         return new BaseResponse<>(postUserRes);
+    }
+
+    /**
+     * 아이디 중복 확인 API
+     * [GET] /users/sign-up
+     * @return ResponseEntity<Boolean> -> 이미 가입된 아이디면 true, 그렇지 않으면 false
+     */
+    @GetMapping("/users/check-id")
+    public ResponseEntity<Boolean> checkDuplicateId(@RequestParam String id) throws BaseException {
+        return ResponseEntity.ok(userService.checkDuplicateId(id));
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
@@ -15,4 +15,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // Optional<User> findByEmailAndStatus(String email, BaseEntity.Status status);
     Optional<User> findById(String id);
     Optional<User> findByEmail(String email);
+
+    boolean existsById(String id);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -39,8 +39,7 @@ public class UserService {
     public PostUserRes createUser(PostUserReq.joinUser postUserReq, MultipartFile profileImage) throws BaseException {
 
         // TODO: 아이디 중복 체크
-        Optional<User> checkUserId = userRepository.findById(postUserReq.getId());
-        if(checkUserId.isPresent()){
+        if(checkDuplicateId(postUserReq.getId())){
             log.info("[createUser]: 이미 존재하는 아이디입니다!");
             throw new BaseException(POST_USERS_EXISTS_ID);
         }
@@ -98,5 +97,14 @@ public class UserService {
      */
     public User getUser(String uuid) throws BaseException {
         return userRepository.findUserByUuid(uuid).orElseThrow(()-> new BaseException(FIND_FAIL_USERNAME));
+    }
+
+    /**
+     * 아이디 중복 확인
+     * [GET]
+     * @return 이미 가입된 아이디면 -> true, 그렇지 않으면 -> false
+     */
+    public boolean checkDuplicateId(String UserId) throws BaseException {
+        return userRepository.existsById(UserId);
     }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 아이디 중복확인
- [ ] 버그 수정 :
- [X] 리펙토링 :  `createUser()`에 있던 아이디 중복확인 기능을 `userService`에 새로운 함수를 생성해서 분리했습니다. (#7) 
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 이유

### 작업 내역

- 아이디 중복확인
- `userRepository`에 아이디 존재 여부를 확인하는 `boolean` 형 JPA 메소드 추가

### 작업 후 기대 동작(스크린샷)
![image](https://github.com/familymoments/family-moments-BE/assets/55887179/82006fa1-2108-4be9-8677-9af624ed5330)

- 이미 가입한 아이디가 존재하면 **true** 출력, 가입한 아이디가 없으면 **false** 출력

### PR 특이 사항

- 이메일 중복확인도 크게 다를 것 같지 않아서, 비슷한 방법으로 구현할 예정입니다!

### Issue Number 

close: #

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
- `createUser`의 인자로 결과값을 넘겨주도록 구현했습니다!