### PR TITLE
feat: 이메일 중복확인 api

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -69,11 +69,21 @@ public class UserController {
 
     /**
      * 아이디 중복 확인 API
-     * [GET] /users/sign-up
+     * [GET] /users/check-id
      * @return ResponseEntity<Boolean> -> 이미 가입된 아이디면 true, 그렇지 않으면 false
      */
     @GetMapping("/users/check-id")
     public ResponseEntity<Boolean> checkDuplicateId(@RequestParam String id) throws BaseException {
         return ResponseEntity.ok(userService.checkDuplicateId(id));
+    }
+
+    /**
+     * 이메일 중복 확인 API
+     * [GET] /users/check-email
+     * @return ResponseEntity<Boolean> -> 이미 가입된 아이디면 true, 그렇지 않으면 false
+     */
+    @GetMapping("/users/check-email")
+    public ResponseEntity<Boolean> checkDuplicateEmail(@RequestParam String email) throws BaseException {
+        return ResponseEntity.ok(userService.checkDuplicateEmail(email));
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
@@ -17,4 +17,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsById(String id);
+    boolean existsByEmail(String email);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -45,8 +45,8 @@ public class UserService {
         }
 
         // TODO: 이메일 중복 체크
-        Optional<User> checkUserEmail = userRepository.findByEmail(postUserReq.getEmail());
-        if(checkUserEmail.isPresent()){
+        // Optional<User> checkUserEmail = userRepository.findByEmail(postUserReq.getEmail());
+        if(checkDuplicateEmail(postUserReq.getEmail())){
             log.info("[createUser]: 이미 존재하는 이메일입니다!");
             throw new BaseException(POST_USERS_EXISTS_EMAIL);
         }
@@ -106,5 +106,14 @@ public class UserService {
      */
     public boolean checkDuplicateId(String UserId) throws BaseException {
         return userRepository.existsById(UserId);
+    }
+
+    /**
+     * 이메일 중복 확인
+     * [GET]
+     * @return 이미 가입된 이메일이면 -> true, 그렇지 않으면 -> false
+     */
+    public boolean checkDuplicateEmail(String email) throws BaseException {
+        return userRepository.existsByEmail(email);
     }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 이메일 중복확인
- [ ] 버그 수정 :
- [X] 리펙토링 :  `createUser()`에 있던 이메일 중복확인 기능을 `userService`에 새로운 함수를 생성해서 분리했습니다. (#7) 
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 이유

### 작업 내역

- 아이디 중복확인
- `userRepository`에 이메일 존재 여부를 확인하는 `boolean` 형 JPA 메소드 추가

### 작업 후 기대 동작(스크린샷)
![image](https://github.com/familymoments/family-moments-BE/assets/55887179/7ab8289c-bca9-49b4-9537-ede188bf0ddb)

- 이미 가입한 이메일이 존재하면 **true** 출력, 가입한 이메일이 없으면 **false** 출력

### PR 특이 사항

### Issue Number 

close: #

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
- `createUser`의 인자로 결과값을 넘겨주도록 구현했습니다!
