### PR TITLE
Feature/user search

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -8,12 +8,15 @@ import com.spring.familymoments.domain.user.model.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
+
+import java.util.List;
 
 import static com.spring.familymoments.config.BaseResponseStatus.*;
 import static com.spring.familymoments.utils.ValidationRegex.*;
@@ -126,5 +129,18 @@ public class UserController {
     public BaseResponse<GetProfileRes> readProfile(@AuthenticationPrincipal User user) {
        GetProfileRes getProfileRes = userService.readProfile(user);
        return new BaseResponse<>(getProfileRes);
+    }
+
+    /**
+     * 유저 검색 API / 가족원 추가 API
+     * [GET] /users
+     * @param keyword null 가능
+     * @param familyId null 가능
+     * @return BaseResponse<List<GetSearchUserRes>>
+     */
+    @GetMapping("/users")
+    public BaseResponse<List<GetSearchUserRes>> searchUser(@RequestParam(value = "keyword", required = false) String keyword, @RequestParam(value = "familyId", required = false) Long familyId, @AuthenticationPrincipal User user) {
+        List<GetSearchUserRes> getSearchUserRes = userService.searchUserById(keyword, familyId, user);
+        return new BaseResponse<>(getSearchUserRes);
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
@@ -1,10 +1,15 @@
 package com.spring.familymoments.domain.user;
 
 import com.spring.familymoments.domain.common.BaseEntity;
+import com.spring.familymoments.domain.common.entity.UserFamily;
 import com.spring.familymoments.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,4 +23,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPassword(String password);
     boolean existsById(String id);
     boolean existsByEmail(String email);
+
+    //유저 검색
+    @Query("SELECT u FROM User u WHERE u.id LIKE :keyword% ORDER BY u.id ASC")
+    Page<User> findTop5ByIdContainingKeywordOrderByIdAsc(String keyword, Pageable pageable);
+    @Query("SELECT u, uf FROM User u LEFT JOIN UserFamily uf ON u.id = uf.userId " +
+            "WHERE (:familyId IS NULL OR uf.familyId = :familyId) AND (u.userId = :userId)")
+    List<Object[]> findUsersByFamilyIdAndUserId(Long familyId, Long userId);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -169,16 +169,14 @@ public class UserService {
      * @return
      */
     public GetProfileRes readProfile(User user) {
-        User member = userRepository.findByEmail(user.getEmail()).orElseThrow(() -> new InternalServerErrorException("token에서 user를 불러오지 못했습니다."));
-
         //Long totalUpload = postRepository.countByWriterId(user);
         Long totalUpload = new Long(0);
 
-        LocalDateTime targetDate = member.getCreatedAt();
+        LocalDateTime targetDate = user.getCreatedAt();
         LocalDateTime currentDate = LocalDateTime.now();
         Long duration = ChronoUnit.DAYS.between(targetDate, currentDate);
 
-        return new GetProfileRes(user.getNickname(), user.getEmail(), totalUpload, duration);
+        return new GetProfileRes(user.getProfileImg(), user.getNickname(), user.getEmail(), totalUpload, duration);
     }
     /**
      * 유저 검색 API

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -3,11 +3,14 @@ package com.spring.familymoments.domain.user;
 import com.spring.familymoments.config.BaseException;
 import com.spring.familymoments.config.advice.exception.InternalServerErrorException;
 import com.spring.familymoments.config.secret.jwt.JwtService;
+import com.spring.familymoments.domain.common.entity.UserFamily;
 import com.spring.familymoments.domain.user.model.*;
 import com.spring.familymoments.domain.user.entity.User;
 import com.spring.familymoments.utils.UuidUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,8 +22,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.spring.familymoments.config.BaseResponseStatus.*;
+import static com.spring.familymoments.domain.common.entity.UserFamily.Status.ACTIVE;
+import static com.spring.familymoments.domain.common.entity.UserFamily.Status.DEACCEPT;
 
 @Slf4j
 @Service
@@ -173,4 +180,40 @@ public class UserService {
 
         return new GetProfileRes(user.getNickname(), user.getEmail(), totalUpload, duration);
     }
+    /**
+     * 유저 검색 API
+     * [GET] /users
+     * @return
+     */
+    public List<GetSearchUserRes> searchUserById(String keyword, Long familyId, User loginUser) {
+        List<GetSearchUserRes> getSearchUserResList = new ArrayList<>();
+
+        PageRequest pageRequest = PageRequest.of(0, 5);
+        Page<User> keywordUserList = userRepository.findTop5ByIdContainingKeywordOrderByIdAsc(keyword, pageRequest);
+
+        for(User keywordUser: keywordUserList) {
+            int appear = 1;
+            if(loginUser.getUserId() == keywordUser.getUserId()) {
+                log.info("[로그인 유저이면 리스트에 추가 X]");
+                continue;
+            }
+            List<Object[]> results = userRepository.findUsersByFamilyIdAndUserId(familyId, keywordUser.getUserId());
+            for(Object[] result : results) {
+                UserFamily userFamily = (UserFamily) result[1];
+                if (userFamily == null) {
+                    System.out.println("UserFamily is null. Skipping...");
+                    continue;
+                }
+                if(userFamily.getStatus() == ACTIVE || userFamily.getStatus() == DEACCEPT) {
+                    log.info("[이미 다른 가족에 초대 대기 중이거나 초대 당한 사람이니까 비활성화]");
+                    appear = 0;
+                    break;
+                }
+            }
+            GetSearchUserRes getSearchUserRes = new GetSearchUserRes(keywordUser.getId(), keywordUser.getProfileImg(), appear);
+            getSearchUserResList.add(getSearchUserRes);
+        }
+        return getSearchUserResList;
+    }
 }
+

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/model/GetProfileRes.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/model/GetProfileRes.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GetProfileRes {
+    private String profileImg;
     private String nickName;
     private String email;
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/model/GetSearchUserRes.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/model/GetSearchUserRes.java
@@ -1,0 +1,16 @@
+package com.spring.familymoments.domain.user.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetSearchUserRes {
+    private String Id;
+    private String profileImg;
+    private int status;
+}


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 유저 검색 api
- [ ] 버그 수정 : 
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [x] 기타 : profile 조회에서 칼럼(profileImg) 누락 추가 

### 변경사항 및 이유
- 회원 정보 조회에서 칼럼 중에 profileImg 누락된 것을 발견하고 추가했습니다.

### 작업 내역
- 유저 검색 시 
상위 5명의 유저가 나타남과 동시에 다른 가족과 관련된 유저의 상태를 비활성화 하는 값**(status)**을 0으로 반환하도록 했습니다.

### 작업 후 기대 동작(스크린샷)

![image](https://github.com/familymoments/family-moments-BE/assets/97500298/574ff523-cfe8-4878-9e87-cc861d9a0b8f)

### PR 특이 사항
- 가족원 추가 초대 부분은 코드로 구현이 되어있지만, 추후에 **테스트가 한번 더 필요**합니다.

- 특이 사항

### Issue Number 

close: #18

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
