### PR TITLE
Feature/user delete

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentWithUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentWithUserRepository.java
@@ -1,0 +1,15 @@
+package com.spring.familymoments.domain.comment;
+
+import com.spring.familymoments.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface CommentWithUserRepository extends JpaRepository<Comment, Long> {
+    //유저가 쓴 모든 댓글들 조회
+    @Query("SELECT c FROM Comment c WHERE c.writer.userId = :userId")
+    List<Comment> findCommentsByUserId(Long userId);
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithUserRepository.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 public interface PostWithUserRepository extends JpaRepository<Post, Long> {
+    //게시글 업로드 수 조회
+    Long countByWriterId(User user);
     //유저가 작성한 모든 게시글 조회
     @Query("SELECT p FROM Post p JOIN FETCH p.writerId u WHERE u.userId = :userId")
     List<Post> findPostByUserId(Long userId);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithUserRepository.java
@@ -1,0 +1,17 @@
+package com.spring.familymoments.domain.post;
+
+import com.spring.familymoments.domain.post.entity.Post;
+import com.spring.familymoments.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface PostWithUserRepository extends JpaRepository<Post, Long> {
+    //유저가 작성한 모든 게시글 조회
+    @Query("SELECT p FROM Post p JOIN FETCH p.writerId u WHERE u.userId = :userId")
+    List<Post> findPostByUserId(Long userId);
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -243,6 +243,7 @@ public class UserController {
     /**
      * 전체 회원정보 조회 API / 화면 외 API
      * [GET] /users/all
+     * @return BaseResponse<List<User>>
      */
     @GetMapping("/users/all")
     public BaseResponse<List<User>> getAllUser() {
@@ -250,4 +251,15 @@ public class UserController {
         return new BaseResponse<>(userList);
     }
 
+    /**
+     * 회원 탈퇴 API
+     * [DELETE] /users
+     * @return BaseResponse<String>
+     */
+    @Transactional
+    @DeleteMapping("/users")
+    public BaseResponse<String> deleteUser(@AuthenticationPrincipal User user) {
+        userService.deleteUser(user.getUserId());
+        return new BaseResponse<>("계정을 삭제했습니다.");
+    }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -239,4 +239,15 @@ public class UserController {
         }
         return new BaseResponse<>("비밀번호가 변경되고 로그아웃 됐습니다.");
     }
+
+    /**
+     * 전체 회원정보 조회 API / 화면 외 API
+     * [GET] /users/all
+     */
+    @GetMapping("/users/all")
+    public BaseResponse<List<User>> getAllUser() {
+        List<User> userList = userService.getAllUser();
+        return new BaseResponse<>(userList);
+    }
+
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -42,10 +42,6 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PostWithUserRepository postWithUserRepository;
-    /**
-     * PostRepository 생성 후 추가 예정
-     * Long countByWriterId(User user);
-     */
     private final FamilyRepository familyRepository;
     private final CommentWithUserRepository commentWithUserRepository;
     private final JwtService jwtService;
@@ -176,8 +172,7 @@ public class UserService {
      * @return
      */
     public GetProfileRes readProfile(User user) {
-        //Long totalUpload = postRepository.countByWriterId(user);
-        Long totalUpload = new Long(0);
+        Long totalUpload = postWithUserRepository.countByWriterId(user);
 
         LocalDateTime targetDate = user.getCreatedAt();
         LocalDateTime currentDate = LocalDateTime.now();

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -249,5 +249,14 @@ public class UserService {
         user.updatePassword(passwordEncoder.encode(patchPwdReq.getNewPassword()));
         userRepository.save(user);
     }
+    /**
+     * 전체 회원정보 조회 API / 화면 외 API
+     * [GET]
+     * @return
+     */
+    public List<User> getAllUser() {
+        List<User> userList = userRepository.findAll();
+        return userList;
+    }
 }
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 전체회원정보조회api, 회원탈퇴api
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 이유

### 작업 내역

1. 회원 탈퇴
- 유저의 모든 게시글 조회, 유저의 모든 댓글 조회를 위해
postwithuserRepository, commentwithuserrepository 파일 생성 후 jpa 관련 메소드 추가했습니다.
2. 프로필 조회 관련 게시글 업로드 수 메소드 주석 해제
postwithuserRepository에 추가했습니다.
3. 전체회원정보조회
화면 외api이지만, 회원 탈퇴를 위해 선행되어야 할것 같아 구현했습니다.

### 작업 후 기대 동작(스크린샷)

### PR 특이 사항
- 회원 탈퇴의 경우, 게시글 조회, 댓글 조회 후 일괄 삭제 방식으로 구현했습니다. (+ CasCade 방식은 위험하다고 해서)
- 테스트들을 mysql에 넣어두고 확인해 보려 했지만, 테스트 값의 date 값 설정 문제로 500 에러가 뜹니다.
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/2badd387-7837-4aa1-bf27-61aa2432dc9e)
- 게시글 생성, 댓글 생성 api가 개발된 이후에 다시 확인하도록 하겠습니다.

### Issue Number 

close: #24

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
