### PR TITLE
Feature/login

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -38,7 +38,7 @@ public enum BaseResponseStatus {
     POST_USERS_INVALID_BIRTH(false, HttpStatus.BAD_REQUEST.value(), "생년월일 형식을 확인해주세요."),
     POST_USERS_EMPTY_NICKNAME(false, HttpStatus.BAD_REQUEST.value(), "닉네임을 입력해주세요."),
     POST_USERS_INVALID_NICKNAME(false, HttpStatus.BAD_REQUEST.value(), "닉네임 형식을 확인해주세요."),
-    FAILED_TO_LOGIN(false,HttpStatus.NOT_FOUND.value(),"없는 아이디거나 비밀번호가 틀렸습니다."),
+    FAILED_TO_LOGIN(false,HttpStatus.NOT_FOUND.value(),"아이디와 비밀번호가 일치하지 않습니다."),
 
     FIND_FAIL_FAMILY(false, HttpStatus.NOT_FOUND.value(), "존재하지 않는 가족입니다."),
     FAILED_INVITE_USER_FAMILY(false, HttpStatus.CONFLICT.value(), "이미 가족에 가입된 회원입니다."),

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentWithUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentWithUserRepository.java
@@ -12,4 +12,7 @@ public interface CommentWithUserRepository extends JpaRepository<Comment, Long> 
     //유저가 쓴 모든 댓글들 조회
     @Query("SELECT c FROM Comment c WHERE c.writer.userId = :userId")
     List<Comment> findCommentsByUserId(Long userId);
+
+    @Query("SELECT c FROM Comment c WHERE c.postId IN (SELECT p FROM Post p WHERE p.writerId.userId = :userId)")
+    List<Comment> findByPostUserID(Long userId);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
@@ -18,4 +18,8 @@ public interface UserFamilyRepository extends JpaRepository<UserFamily, Long> {
     @Query(value = "SELECT uf FROM UserFamily uf WHERE uf.userId = ?1 "
             + "ORDER BY uf.createdAt DESC")
     List<UserFamily> findAllByUserIdOrderByCreatedAtDesc(User userId);
+
+    //회원 탈퇴 시, UserFamily 매핑 테이블 해제를 위한 조회
+    @Query("SELECT uf FROM UserFamily uf WHERE uf.userId.userId = :userId")
+    List<UserFamily> findUserFamilyByUserId(Long userId);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
@@ -1,8 +1,10 @@
 package com.spring.familymoments.domain.family;
 
 import com.spring.familymoments.domain.family.entity.Family;
+import com.spring.familymoments.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FamilyRepository extends JpaRepository<Family, Long> {
@@ -10,4 +12,6 @@ public interface FamilyRepository extends JpaRepository<Family, Long> {
 
     Optional<Family> findByInviteCode(String inviteCode);
 
+    //회원 탈퇴 시, 가족 생성자 권한 여부를 확인하기 위한 조회
+    List<Family> findByOwner(User user);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithUserRepository.java
@@ -14,6 +14,6 @@ public interface PostWithUserRepository extends JpaRepository<Post, Long> {
     //게시글 업로드 수 조회
     Long countByWriterId(User user);
     //유저가 작성한 모든 게시글 조회
-    @Query("SELECT p FROM Post p JOIN FETCH p.writerId u WHERE u.userId = :userId")
+    @Query("SELECT p FROM Post p WHERE p.writerId.userId = :userId")
     List<Post> findPostByUserId(Long userId);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -175,8 +175,13 @@ public class UserController {
      */
     @GetMapping("/users")
     public BaseResponse<List<GetSearchUserRes>> searchUser(@RequestParam(value = "keyword", required = false) String keyword, @RequestParam(value = "familyId", required = false) Long familyId, @AuthenticationPrincipal User user) {
-        List<GetSearchUserRes> getSearchUserRes = userService.searchUserById(keyword, familyId, user);
-        return new BaseResponse<>(getSearchUserRes);
+        if(familyId != null) {
+            List<GetSearchUserRes> getSearchUserRes = userService.searchUserById(keyword, familyId, user);
+            return new BaseResponse<>(getSearchUserRes);
+        }
+        else {
+            return new BaseResponse<>(false, "familyId 값이 없습니다", 400);
+        }
     }
     /**
      * 초대 리스트 확인 API
@@ -185,8 +190,12 @@ public class UserController {
      */
     @GetMapping("/users/invitation")
     public BaseResponse<List<GetInvitationRes>> getInvitationList(@AuthenticationPrincipal User user){
-        List<GetInvitationRes> getInvitationRes = userService.getInvitationList(user);
-        return new BaseResponse<>(getInvitationRes);
+        try {
+            List<GetInvitationRes> getInvitationRes = userService.getInvitationList(user);
+            return new BaseResponse<>(getInvitationRes);
+        } catch(NoSuchElementException e) {
+            return new BaseResponse<>(false, e.getMessage(), 400);
+        }
     }
     /**
      * 회원 정보 수정 API

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -282,7 +282,11 @@ public class UserController {
     @Transactional
     @DeleteMapping("/users")
     public BaseResponse<String> deleteUser(@AuthenticationPrincipal User user) {
-        userService.deleteUser(user.getUserId());
-        return new BaseResponse<>("계정을 삭제했습니다.");
+        try {
+            userService.deleteUser(user);
+            return new BaseResponse<>("계정을 삭제했습니다.");
+        } catch (IllegalAccessException e) {
+            return new BaseResponse(false, e.getMessage(), 500);
+        }
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -118,9 +118,13 @@ public class UserController {
      * @return BaseResponse<>(postLoginRes)
      */
     @PostMapping("/users/log-in")
-    public BaseResponse<PostLoginRes> login(@RequestBody PostLoginReq postLoginReq, HttpServletResponse response) throws InternalServerErrorException {
-        PostLoginRes postLoginRes = userService.createLogin(postLoginReq, response);
-        return new BaseResponse<>(postLoginRes);
+    public BaseResponse<PostLoginRes> login(@RequestBody PostLoginReq postLoginReq, HttpServletResponse response) {
+        try{
+            PostLoginRes postLoginRes = userService.createLogin(postLoginReq, response);
+            return new BaseResponse<>(postLoginRes);
+        } catch(NoSuchElementException e){
+            return new BaseResponse<>(FAILED_TO_LOGIN);
+        }
     }
 
     /**

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
@@ -30,7 +30,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     //유저 검색
     @Query("SELECT u FROM User u WHERE u.id LIKE :keyword% ORDER BY u.id ASC")
     Page<User> findTop5ByIdContainingKeywordOrderByIdAsc(String keyword, Pageable pageable);
-    @Query("SELECT u, uf FROM User u LEFT JOIN UserFamily uf ON u.id = uf.userId " +
-            "WHERE (:familyId IS NULL OR uf.familyId = :familyId) AND (u.userId = :userId)")
+    @Query("SELECT u, uf FROM User u LEFT JOIN UserFamily uf ON u.userId = uf.userId.userId " +
+            "WHERE (uf.familyId.familyId = :familyId) AND (u.userId = :userId)")
     List<Object[]> findUsersByFamilyIdAndUserId(Long familyId, Long userId);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -139,18 +139,18 @@ public class UserService {
      * [POST]
      * @return ok
      */
-    public PostLoginRes createLogin(PostLoginReq postLoginReq, HttpServletResponse response) throws InternalServerErrorException {
-        // TODO: 로그인 아이디 확인 db의 Id랑 같은지 확인하고 토큰 돌려주기
+    public PostLoginRes createLogin(PostLoginReq postLoginReq, HttpServletResponse response) {
+        // 로그인 아이디 확인 db의 Id랑 같은지 확인하고 토큰 돌려주기
         User user = userRepository.findById(postLoginReq.getId())
-                .orElseThrow(() -> new InternalServerErrorException("아이디가 일치하지 않습니다."));
+                .orElseThrow(() -> new NoSuchElementException("아이디가 일치하지 않습니다."));
         if(!passwordEncoder.matches(postLoginReq.getPassword(), user.getPassword())) {
-            throw new InternalServerErrorException("비밀번호가 일치하지 않습니다.");
+            throw new NoSuchElementException("비밀번호가 일치하지 않습니다.");
         }
-        // TODO: 로그인 시 토큰 생성해서 header에 붙임.
+        // 로그인 시 토큰 생성해서 header에 붙이기
         String token = jwtService.createToken(user.getUuid());
         response.setHeader("X-AUTH-TOKEN", token);
 
-        // TODO: 클라이언트에 cookie로 토큰도 보냄
+        // 클라이언트에 cookie로 토큰도 보내기
         Cookie cookie = new Cookie("X-AUTH-TOKEN", token);
         cookie.setPath("/");
         cookie.setHttpOnly(true);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -187,6 +187,7 @@ public class UserService {
      * [GET] /users
      * @return
      */
+    @Transactional
     public List<GetSearchUserRes> searchUserById(String keyword, Long familyId, User loginUser) {
         List<GetSearchUserRes> getSearchUserResList = new ArrayList<>();
 
@@ -194,12 +195,13 @@ public class UserService {
         Page<User> keywordUserList = userRepository.findTop5ByIdContainingKeywordOrderByIdAsc(keyword, pageRequest);
 
         for(User keywordUser: keywordUserList) {
+            Long checkUserId = keywordUser.getUserId();
             int appear = 1;
-            if(loginUser.getUserId() == keywordUser.getUserId()) {
+            if(loginUser.getUserId() == checkUserId) {
                 log.info("[로그인 유저이면 리스트에 추가 X]");
                 continue;
             }
-            List<Object[]> results = userRepository.findUsersByFamilyIdAndUserId(familyId, keywordUser.getUserId());
+            List<Object[]> results = userRepository.findUsersByFamilyIdAndUserId(familyId, checkUserId);
             for(Object[] result : results) {
                 UserFamily userFamily = (UserFamily) result[1];
                 if (userFamily == null) {


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 유저 검색 api, 회원 탈퇴 api
- [x] 리펙토링 :  로그인 api
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

1. 로그인 api의 경우, 예외처리를 자바 내부 예외처리로 변경하고, 메세지 내용을 수정했습니다.
2. 유저 검색 api나 회원 탈퇴 api의 경우, 이전에 테스트 하지 못해 오류가 났던 부분들을 수정했습니다.

### 작업 내역

1. Login 관련 예외처리 내용 수정 -> 테스트 완료
3. 유저 검색 status 관련 수정 -> jsql 재작성 -> 테스트 완료
4. 회원 탈퇴 관련 수정 -> 테스트 완료

### 작업 후 기대 동작(스크린샷)
1. Login 
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/6149ba07-9a6d-44c9-b84f-6dd69e92c549)
2. 유저 검색 -> status 의도한 대로 적용됨
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/34278424-6aa3-42b6-b0f4-46365e9ac9ce)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/7c7ea465-1eef-4179-8e05-45d97c3f9375)
3. 회원 탈퇴
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/59898347-fabc-40c3-91d8-aa60af1c181a)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/88d6c092-5aa4-49db-b69f-f493d4b38538)


### PR 특이 사항

회원 탈퇴의 경우 아래의 순서대로 이루어져야 cannot delete 오류가 나지 않습니다.

로그인 유저의 댓글 일괄 삭제
로그인 유저의 게시글 일괄 삭제
그 전에 로그인 유저가 작성한 게시글 속 댓글들 일괄 삭제
가족 생성자면 예외처리
로그인 유저의 참여한 유저가족매핑 삭제
로그인 유저 삭제

### Issue Number 

close: 
#11 
#18
#24

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
