### PR TITLE
feat: 게시글 좋아요 생성 및 삭제

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentWithUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentWithUserRepository.java
@@ -18,7 +18,7 @@ public interface CommentWithUserRepository extends JpaRepository<Comment, Long> 
     @Query("SELECT c FROM Comment c WHERE c.writer.userId = :userId")
     List<Comment> findCommentsByUserId(Long userId);
 
-    @Query("SELECT c FROM Comment c WHERE c.postId IN (SELECT p FROM Post p WHERE p.writerId.userId = :userId)")
+    @Query("SELECT c FROM Comment c WHERE c.postId IN (SELECT p FROM Post p WHERE p.writer.userId = :userId)")
     List<Comment> findByPostUserID(Long userId);
 
     // 게시글 내의 모든 댓글 조회

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithLoveRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithLoveRepository.java
@@ -1,0 +1,14 @@
+package com.spring.familymoments.domain.post;
+
+import com.spring.familymoments.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PostWithLoveRepository extends JpaRepository<Post, Long> {
+
+    Optional<Post> findByPostId(Long postId);
+
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithUserRepository.java
@@ -13,9 +13,9 @@ import java.util.List;
 
 public interface PostWithUserRepository extends JpaRepository<Post, Long> {
     //현재 가족에서의 내 게시글 업로드 수
-    Long countByWriterIdAndFamilyId(User user, Family family);
+    Long countByWriterAndFamilyId(User user, Family family);
     //유저가 작성한 모든 게시글 조회
-    @Query("SELECT p FROM Post p WHERE p.writerId.userId = :userId")
+    @Query("SELECT p FROM Post p WHERE p.writer.userId = :userId")
     List<Post> findPostByUserId(Long userId);
 
     // 가족 내에 속한 모든 게시글 조회

--- a/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveController.java
@@ -1,0 +1,49 @@
+package com.spring.familymoments.domain.postLove;
+
+import com.spring.familymoments.config.BaseResponse;
+import com.spring.familymoments.domain.postLove.model.PostLoveReq;
+import com.spring.familymoments.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class PostLoveController {
+
+    private final PostLoveService postLoveService;
+
+    /**
+     * 게시물 내 하트 생성
+     * [POST] /postloves
+     * @return BaseResponse<String>
+     */
+    @PostMapping("/postloves")
+    public BaseResponse<String> createPostLove(@AuthenticationPrincipal User user,
+                                               @RequestParam Long postId,
+                                               @RequestBody PostLoveReq postLoveReq){
+
+        PostLoveReq newPostLove = new PostLoveReq(postLoveReq.getPostId());
+        postLoveService.createLove(user, newPostLove);
+
+        return new BaseResponse<>("게시글에 좋아요를 누르셨습니다!");
+    }
+
+    /**
+     * 게시물 내 하트 삭제
+     * [POST] /postloves
+     * @return BaseResponse<String>
+     */
+    @DeleteMapping("/postloves")
+    public BaseResponse<String> deletePostLove(@AuthenticationPrincipal User user,
+                                               @RequestParam Long postId,
+                                               @RequestBody PostLoveReq postLoveReq){
+
+        PostLoveReq newPostLove = new PostLoveReq(postLoveReq.getPostId());
+        postLoveService.deleteLove(user, newPostLove);
+
+        return new BaseResponse<>("게시글 좋아요를 취소하셨습니다.");
+    }
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveRepository.java
@@ -1,0 +1,17 @@
+package com.spring.familymoments.domain.postLove;
+
+import com.spring.familymoments.domain.post.entity.Post;
+import com.spring.familymoments.domain.postLove.entity.PostLove;
+import com.spring.familymoments.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PostLoveRepository extends JpaRepository<PostLove, Long> {
+
+    Optional<PostLove> findByPostIdAndUserId(Post post, User user);
+
+    boolean existsByPostIdAndUserId(Post post, User user);
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveService.java
@@ -1,0 +1,75 @@
+package com.spring.familymoments.domain.postLove;
+
+import com.spring.familymoments.config.advice.exception.InternalServerErrorException;
+import com.spring.familymoments.domain.post.PostWithLoveRepository;
+import com.spring.familymoments.domain.post.entity.Post;
+import com.spring.familymoments.domain.postLove.entity.PostLove;
+import com.spring.familymoments.domain.postLove.model.PostLoveReq;
+import com.spring.familymoments.domain.user.UserRepository;
+import com.spring.familymoments.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostLoveService {
+
+    private final PostLoveRepository postLoveRepository;
+    private final UserRepository userRepository;
+    private final PostWithLoveRepository postWithLoveRepository;
+
+    /**
+     * createLove
+     * [POST]
+     * @return
+     */
+    @Transactional
+    public void createLove(User user, PostLoveReq postLoveReq) {
+
+        User member = userRepository.findById(user.getId())
+                .orElseThrow(() -> new NoSuchElementException("[좋아요 누르기] 존재하지 않는 아이디입니다."));
+
+        Post post = postWithLoveRepository.findByPostId(postLoveReq.getPostId())
+                .orElseThrow(() -> new NoSuchElementException("[좋아요 누르기] 존재하지 않는 게시물입니다."));
+
+        if(postLoveRepository.existsByPostIdAndUserId(post, member)){
+            throw new InternalServerErrorException("이미 좋아요를 누른 게시물입니다.");
+        }
+
+        PostLove postLove = PostLove.builder()
+                .postId(post)
+                .userId(member)
+                .build();
+
+        postLoveRepository.save(postLove);
+    }
+
+    /**
+     * deleteLove
+     * [DELETE]
+     * @return
+     */
+    @Transactional
+    public void deleteLove(User user, PostLoveReq postLoveReq) {
+
+        User member = userRepository.findById(user.getId())
+                .orElseThrow(() -> new NoSuchElementException("[좋아요 취소] 존재하지 않는 아이디입니다."));
+
+        Post post = postWithLoveRepository.findByPostId(postLoveReq.getPostId())
+                .orElseThrow(() -> new NoSuchElementException("[좋아요 취소] 존재하지 않는 게시물입니다."));
+
+        if(!postLoveRepository.existsByPostIdAndUserId(post, member)){
+            throw new InternalServerErrorException("좋아요를 누르지 않아 취소할 수 없습니다.");
+        }
+
+        PostLove postLove = postLoveRepository.findByPostIdAndUserId(post, member)
+                .orElseThrow(() -> new NoSuchElementException("좋아요를 누르지 않아 취소할 수 없습니다."));
+
+        postLoveRepository.delete(postLove);
+    }
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/postLove/model/PostLoveReq.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/postLove/model/PostLoveReq.java
@@ -1,0 +1,16 @@
+package com.spring.familymoments.domain.postLove.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostLoveReq {
+
+    private Long postId;
+
+    public PostLoveReq(Long postId){
+        this.postId = postId;
+    }
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -179,7 +179,7 @@ public class UserService {
         Family family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new NoSuchElementException("현재 가족정보를 불러오지 못했습니다."));
 
-        Long totalUpload = postWithUserRepository.countByWriterIdAndFamilyId(user, family);
+        Long totalUpload = postWithUserRepository.countByWriterAndFamilyId(user, family);
 
         LocalDateTime targetDate = user.getCreatedAt();
         LocalDateTime currentDate = LocalDateTime.now();


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [X] 신규 기능 추가 : 게시글 좋아요 생성 및 삭제
- [X] 버그 수정 : 코드에 남아있는 `writerId`를 `writer`로 수정
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 코드에 남아있는 `writerId`를 `writer`로 수정

### 작업 내역

- 게시글 좋아요 생성 및 삭제

### 작업 후 기대 동작(스크린샷)

- **게시글 좋아요 생성**
![image](https://github.com/familymoments/family-moments-BE/assets/55887179/8853d1c5-d260-423a-a1a6-95387e5a9120)
- **게시글 좋아요 삭제**
![image](https://github.com/familymoments/family-moments-BE/assets/55887179/b1ec8d8d-6504-4295-b80c-f2c94e4887fa)

**예외처리**는 2가지 경우에 대해서 처리했습니다.
1. 이미 좋아요를 누른 게시글에 다시 좋아요를 누르려고 하는 경우
2. 좋아요를 누르지 않은 게시글의 좋아요를 취소하려는 경우

### PR 특이 사항

- 시간이 없어서 게시글 좋아요 생성 및 삭제를 같은 브랜치에 만들었습니다!

### Issue Number 

close: #

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 일단 오류를 수정하느라 급하게 PR를 반영했는데, 요청하신대로 처리가 되었는지 꼭 확인 부탁드립니다! ㅠㅠ (@zzo3ozz)
- url과 관련하여 현재 양쪽 모두 `@RequestParam`으로 `postId`를 넘겨주는 상태인데, 확인 부탁드립니다!