### PR TITLE
fix: 게시글 좋아요 생성 및 삭제

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveController.java
@@ -21,11 +21,9 @@ public class PostLoveController {
      * @return BaseResponse<String>
      */
     @PostMapping("/postloves")
-    public BaseResponse<String> createPostLove(@AuthenticationPrincipal User user,
-                                               @RequestParam Long postId,
-                                               @RequestBody PostLoveReq postLoveReq){
+    public BaseResponse<String> createPostLove(@AuthenticationPrincipal User user, @RequestParam Long postId){
 
-        PostLoveReq newPostLove = new PostLoveReq(postLoveReq.getPostId());
+        PostLoveReq newPostLove = new PostLoveReq(postId);
         postLoveService.createLove(user, newPostLove);
 
         return new BaseResponse<>("게시글에 좋아요를 누르셨습니다!");
@@ -33,15 +31,13 @@ public class PostLoveController {
 
     /**
      * 게시물 내 하트 삭제
-     * [POST] /postloves
+     * [DELETE] /postloves
      * @return BaseResponse<String>
      */
     @DeleteMapping("/postloves")
-    public BaseResponse<String> deletePostLove(@AuthenticationPrincipal User user,
-                                               @RequestParam Long postId,
-                                               @RequestBody PostLoveReq postLoveReq){
+    public BaseResponse<String> deletePostLove(@AuthenticationPrincipal User user, @RequestParam Long postId){
 
-        PostLoveReq newPostLove = new PostLoveReq(postLoveReq.getPostId());
+        PostLoveReq newPostLove = new PostLoveReq(postId);
         postLoveService.deleteLove(user, newPostLove);
 
         return new BaseResponse<>("게시글 좋아요를 취소하셨습니다.");


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [X] 리펙토링 : `PostLoveController`의 `@RequestBody` 삭제
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 인자로 넘겨주는 값이 중복되어 하나를 삭제하였습니다.

### 작업 내역

-  `PostLoveController`의 `@RequestBody` 삭제 

### 작업 후 기대 동작(스크린샷)

- **게시글 좋아요 생성**
![image](https://github.com/familymoments/family-moments-BE/assets/55887179/6078f35a-83a8-4c87-956c-110518976e3a)
- **게시글 좋아요 삭제**
![image](https://github.com/familymoments/family-moments-BE/assets/55887179/09a0a380-8d89-45d3-a2d9-4988bddb7fcb)

**예외처리**는 2가지 경우에 대해서 처리했습니다.
1. 이미 좋아요를 누른 게시글에 다시 좋아요를 누르려고 하는 경우
2. 좋아요를 누르지 않은 게시글의 좋아요를 취소하려는 경우

### PR 특이 사항


### Issue Number 

close: #

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 요청하신대로 반영했습니다! (@zzo3ozz)