### PR TITLE
feat: post 좋아요한 유저 리스트

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -70,11 +70,12 @@ public enum BaseResponseStatus {
 
     minnie_POSTS_INVALIED_USER(false, HttpStatus.FORBIDDEN.value(), "수정 권한이 없습니다."),
     minnie_POSTS_WRONG_POST_ID(false, HttpStatus.NOT_FOUND.value(), "유효하지 않은 postId 입니다."),
-    minnie_POSTS_EMPTY_POST(false, HttpStatus.NOT_FOUND.value(), "post가 존재하지 않습니다."),
+    minnie_POSTS_NON_EXISTS_POST(false, HttpStatus.NOT_FOUND.value(), "post가 존재하지 않습니다."),
     minnie_POSTS_EMPTY_UPDATE(false, HttpStatus.BAD_REQUEST.value(), "수정할 내용을 보내주세요."),
     minnie_POSTS_EMPTY_CONTENT(false, HttpStatus.BAD_REQUEST.value(), "내용을 입력해주세요."),
     minnie_POSTS_EMPTY_IMAGE(false, HttpStatus.BAD_REQUEST.value(), "img1에 이미지를 지정해주세요."),
-    minnie_POSTS_EMPTY_POST_INFO(false, HttpStatus.BAD_REQUEST.value(), "postInfo가 포함되어야 합니다.");
+    minnie_POSTS_EMPTY_POST_INFO(false, HttpStatus.BAD_REQUEST.value(), "postInfo가 포함되어야 합니다."),
+    minnie_POSTLOVES_NON_EXISTS_LOVE(false, HttpStatus.NOT_FOUND.value(), "좋아요가 존재하지 않습니다.");
 
 
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -6,7 +6,9 @@ import com.spring.familymoments.domain.post.model.MultiPostRes;
 import com.spring.familymoments.domain.post.model.PostInfoReq;
 import com.spring.familymoments.domain.post.model.PostReq;
 import com.spring.familymoments.domain.post.model.SinglePostRes;
+import com.spring.familymoments.domain.postLove.PostLoveService;
 import com.spring.familymoments.domain.user.entity.User;
+import com.spring.familymoments.domain.user.model.CommentRes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,6 +27,7 @@ import static com.spring.familymoments.config.BaseResponseStatus.*;
 @RequestMapping("/posts")
 public class PostController {
     private final PostService postService;
+    private final PostLoveService postLoveService;
 
     /**
      * 게시글 작성 API
@@ -158,7 +161,7 @@ public class PostController {
 
     /**
      * 특정 게시글 조회 API
-     * [GET] /posts?{postId}
+     * [GET] /posts/{postId}
      * @return BaseResponse<SinglePostRes>
      */
     @ResponseBody
@@ -168,6 +171,22 @@ public class PostController {
             SinglePostRes singlePostRes = postService.getPost(user.getUserId(), postId);
 
             return new BaseResponse<>(singlePostRes);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 좋아요 목록 조회 API
+     * [GET] /posts/{postId}/postLoves
+     * @return BaseResponse<SinglePostRes>
+     */
+    @GetMapping("/{postId}/post-loves")
+    public BaseResponse<List<CommentRes>> getLovedList(@PathVariable long postId) {
+        try {
+            List<CommentRes> heartedList = postLoveService.getHeartList(postId);
+
+            return new BaseResponse<>(heartedList);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostRepository.java
@@ -1,5 +1,6 @@
 package com.spring.familymoments.domain.post;
 
+import com.spring.familymoments.domain.common.BaseEntity;
 import com.spring.familymoments.domain.post.entity.Post;
 import com.spring.familymoments.domain.post.model.MultiPostRes;
 import com.spring.familymoments.domain.post.model.SinglePostRes;
@@ -48,4 +49,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "LEFT JOIN PostLove pl On p = pl.postId AND pl.userId.userId = :userId " +
             "WHERE p.postId = :postId")
     SinglePostRes findByPostId(@Param("userId") long userId, @Param("postId") long postId);
+
+    Post findByPostIdAndStatus(long postId, BaseEntity.Status status);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -75,10 +75,10 @@ public class PostService {
     // post update
     @Transactional
     public SinglePostRes editPost(User user, long postId, PostReq postReq) throws BaseException {
-        Post editedPost = postRepository.findById(postId).orElseThrow(() -> new BaseException(minnie_POSTS_EMPTY_POST));
+        Post editedPost = postRepository.findById(postId).orElseThrow(() -> new BaseException(minnie_POSTS_NON_EXISTS_POST));
 
         if(editedPost.getStatus() == BaseEntity.Status.INACTIVE) {
-            throw new BaseException(minnie_POSTS_EMPTY_POST);
+            throw new BaseException(minnie_POSTS_NON_EXISTS_POST);
         }
 
         if(!Objects.equals(editedPost.getWriter().getUserId(), user.getUserId())) {
@@ -122,10 +122,10 @@ public class PostService {
     // post delete
     @Transactional
     public void deletePost(User user, long postId) throws BaseException {
-        Post deletedPost = postRepository.findById(postId).orElseThrow(() -> new BaseException(minnie_POSTS_EMPTY_POST));
+        Post deletedPost = postRepository.findById(postId).orElseThrow(() -> new BaseException(minnie_POSTS_NON_EXISTS_POST));
 
         if(deletedPost.getStatus() == BaseEntity.Status.INACTIVE) {
-            throw new BaseException(minnie_POSTS_EMPTY_POST);
+            throw new BaseException(minnie_POSTS_NON_EXISTS_POST);
         }
 
         if(!deletedPost.getWriter().getUserId().equals(user.getUserId())) {
@@ -141,7 +141,7 @@ public class PostService {
         List<MultiPostRes> multiPostReses = postRepository.findByFamilyId(familyId, userId, pageable);
 
         if(multiPostReses.isEmpty()) {
-            throw new BaseException(minnie_POSTS_EMPTY_POST);
+            throw new BaseException(minnie_POSTS_NON_EXISTS_POST);
         }
 
         return multiPostReses;
@@ -153,7 +153,7 @@ public class PostService {
         List<MultiPostRes> multiPostReses = postRepository.findByFamilyId(familyId, userId, postId, pageable);
 
         if(multiPostReses.isEmpty()) {
-            throw new BaseException(minnie_POSTS_EMPTY_POST);
+            throw new BaseException(minnie_POSTS_NON_EXISTS_POST);
         }
 
         return multiPostReses;

--- a/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveRepository.java
@@ -3,15 +3,25 @@ package com.spring.familymoments.domain.postLove;
 import com.spring.familymoments.domain.post.entity.Post;
 import com.spring.familymoments.domain.postLove.entity.PostLove;
 import com.spring.familymoments.domain.user.entity.User;
+import com.spring.familymoments.domain.user.model.CommentRes;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PostLoveRepository extends JpaRepository<PostLove, Long> {
 
     Optional<PostLove> findByPostIdAndUserId(Post post, User user);
+
+    @Query("SELECT new com.spring.familymoments.domain.user.model.CommentRes(u.nickname, u.profileImg) " +
+            "FROM PostLove pl JOIN pl.userId u " +
+            "WHERE pl.postId = :post " +
+            "AND pl.status = 'ACTIVE' " +
+            "order by pl.updatedAt ASC")
+    List<CommentRes> findByPost(Post post);
 
     boolean existsByPostIdAndUserId(Post post, User user);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveService.java
@@ -1,18 +1,26 @@
 package com.spring.familymoments.domain.postLove;
 
+import com.spring.familymoments.config.BaseException;
 import com.spring.familymoments.config.advice.exception.InternalServerErrorException;
+import com.spring.familymoments.domain.common.BaseEntity;
+import com.spring.familymoments.domain.post.PostRepository;
 import com.spring.familymoments.domain.post.PostWithLoveRepository;
 import com.spring.familymoments.domain.post.entity.Post;
 import com.spring.familymoments.domain.postLove.entity.PostLove;
 import com.spring.familymoments.domain.postLove.model.PostLoveReq;
 import com.spring.familymoments.domain.user.UserRepository;
 import com.spring.familymoments.domain.user.entity.User;
+import com.spring.familymoments.domain.user.model.CommentRes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
+
+import static com.spring.familymoments.config.BaseResponseStatus.minnie_POSTLOVES_NON_EXISTS_LOVE;
+import static com.spring.familymoments.config.BaseResponseStatus.minnie_POSTS_WRONG_POST_ID;
 
 @Slf4j
 @Service
@@ -22,6 +30,7 @@ public class PostLoveService {
     private final PostLoveRepository postLoveRepository;
     private final UserRepository userRepository;
     private final PostWithLoveRepository postWithLoveRepository;
+    private final PostRepository postRepository;
 
     /**
      * createLove
@@ -71,5 +80,23 @@ public class PostLoveService {
                 .orElseThrow(() -> new NoSuchElementException("좋아요를 누르지 않아 취소할 수 없습니다."));
 
         postLoveRepository.delete(postLove);
+    }
+
+    // 좋아요한 user의 nickName 및 profileImg return
+    @Transactional
+    public List<CommentRes> getHeartList(long postId) throws BaseException {
+        Post post = postRepository.findByPostIdAndStatus(postId, BaseEntity.Status.ACTIVE);
+
+        if(post == null) {
+            throw new BaseException(minnie_POSTS_WRONG_POST_ID);
+        }
+
+        List<CommentRes> users = postLoveRepository.findByPost(post);
+
+        if(users.isEmpty()) {
+            throw new BaseException(minnie_POSTLOVES_NON_EXISTS_LOVE);
+        }
+
+        return users;
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/model/CommentRes.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/model/CommentRes.java
@@ -1,0 +1,17 @@
+package com.spring.familymoments.domain.user.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentRes {
+    // Comment 및 좋아요 유저 정보 위한 DTO
+    String nickName;
+    String profileImg;
+
+    public CommentRes(String nickName, String profileImg) {
+        this.nickName = nickName;
+        this.profileImg = profileImg;
+    }
+}


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 좋아요한 유저 리스트
- [ ] 버그 수정 :
- [x] 리펙토링 : Post관련 BaseStatus enum명 변경
- [ ] 문서 업데이트 :
- [ ] 기타 : 


### 작업 내역

- minnie_POSTS_EMPTY_POST -> minnie_POSTS_NON_EXISTS_POST로 리팩토링
- post 좋아요한 유저 리스트
해당 내역은 updatedAt 기준, 오름차순(오래된 순)으로 정렬된 상태로 전송됩니다.
profileImg값이 null인 경우, null로 전송됩니다.


### 작업 후 기대 동작(스크린샷)
![TalkMedia_i_cc8370c549ec png](https://github.com/familymoments/family-moments-BE/assets/90233522/8f646862-47a2-4fbe-bbd7-03ded30c617c)

