### PR TITLE
feat: 특정 일 기준 post 목록 조회

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -177,6 +177,47 @@ public class PostController {
     }
 
     /**
+     * 특정 일 최신 10개 게시글 조회 API
+     * [GET] /posts/calendar?familyId={가족인덱스}&year={년}&month={월}&day={일}
+     * @return BaseResponse<List<MultiPostRes>>
+     */
+    @ResponseBody
+    @GetMapping(value = "/calendar", params = {"familyId", "year", "month", "day"})
+    public  BaseResponse<List<MultiPostRes>> getPostsWithDate(@AuthenticationPrincipal User user,
+                                                        @RequestParam("familyId") long familyId,
+                                                        @RequestParam("year") int year,
+                                                        @RequestParam("month") int month,
+                                                        @RequestParam("day") int day) {
+        try {
+            List<MultiPostRes> multiPostRes = postService.getPostsOfDate(user.getUserId(), familyId, year, month, day);
+            return new BaseResponse<>(multiPostRes);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 특정 일 최신 10개 게시글 조회 API
+     * [GET] /posts/calendar?familyId={가족인덱스}&year={년}&month={월}&day={일}
+     * @return BaseResponse<List<MultiPostRes>>
+     */
+    @ResponseBody
+    @GetMapping(value = "/calendar", params = {"familyId", "year", "month", "day", "postId"})
+    public  BaseResponse<List<MultiPostRes>> getPostsWithDate(@AuthenticationPrincipal User user,
+                                                              @RequestParam("familyId") long familyId,
+                                                              @RequestParam("year") int year,
+                                                              @RequestParam("month") int month,
+                                                              @RequestParam("day") int day,
+                                                              @RequestParam("postId") long postId) {
+        try {
+            List<MultiPostRes> multiPostRes = postService.getPostsOfDate(user.getUserId(), familyId, year, month, day, postId);
+            return new BaseResponse<>(multiPostRes);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
      * 좋아요 목록 조회 API
      * [GET] /posts/{postId}/postLoves
      * @return BaseResponse<SinglePostRes>

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -34,6 +35,28 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "ORDER BY p.postId DESC")
     List<MultiPostRes> findByFamilyId(@Param("familyId") long familyId, @Param("userId") long userId, @Param("postId") long postId, Pageable pageable);
 
+    @Query("SELECT " +
+            "new com.spring.familymoments.domain.post.model.MultiPostRes" +
+            "(p.postId, u.nickname, u.profileImg, p.content, CONCAT(COALESCE(p.img1, ''), ',', COALESCE(p.img2, ''), ',', COALESCE(p.img3, ''), ',', COALESCE(p.img4, '')), p.createdAt, pl.status) " +
+            "FROM Post p JOIN p.writer u " +
+            "LEFT JOIN PostLove pl On p = pl.postId AND pl.userId.userId = :userId " +
+            "WHERE p.familyId.familyId = :familyId " +
+            "AND p.status = 'ACTIVE' " +
+            "AND FUNCTION('DATE', p.createdAt)  = FUNCTION('DATE', :date) " +
+            "ORDER BY p.postId DESC")
+    List<MultiPostRes> findByFamilyIdWithDate(@Param("familyId") long familyId, @Param("userId") long userId, @Param("date") LocalDateTime date, Pageable pageable);
+
+    @Query("SELECT " +
+            "new com.spring.familymoments.domain.post.model.MultiPostRes" +
+            "(p.postId, u.nickname, u.profileImg, p.content, CONCAT(COALESCE(p.img1, ''), ',', COALESCE(p.img2, ''), ',', COALESCE(p.img3, ''), ',', COALESCE(p.img4, '')), p.createdAt, pl.status) " +
+            "FROM Post p JOIN p.writer u " +
+            "LEFT JOIN PostLove pl On p = pl.postId AND pl.userId.userId = :userId " +
+            "WHERE p.familyId.familyId = :familyId " +
+            "AND p.status = 'ACTIVE' " +
+            "AND FUNCTION('DATE', p.createdAt)  = FUNCTION('DATE', :date) " +
+            "AND p.postId < :postId " +
+            "ORDER BY p.postId DESC")
+    List<MultiPostRes> findByFamilyIdWithDateAfterPostId(@Param("familyId") long familyId, @Param("userId") long userId, @Param("date") LocalDateTime date, @Param("postId") long postId, Pageable pageable);
 
     @Modifying
     @Transactional

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -17,6 +17,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -173,5 +176,41 @@ public class PostService {
         }
 
         return singlePostRes;
+    }
+
+    // 특정 일 최신 post 조회
+    @Transactional
+    public List<MultiPostRes> getPostsOfDate(long userId, long familyId, int year, int month, int day) throws BaseException{
+        LocalDate date = LocalDate.of(year, month, day);
+        LocalTime dummy = LocalTime.MIDNIGHT; // LocalDateTime 변수 생성을 위한 dummy 값
+
+        LocalDateTime dateTime = LocalDateTime.of(date, dummy);
+
+        Pageable pageable = PageRequest.of(0, 10);
+        List<MultiPostRes> posts = postRepository.findByFamilyIdWithDate(familyId, userId, dateTime, pageable);
+
+        if(posts.isEmpty()) {
+            throw new BaseException(minnie_POSTS_NON_EXISTS_POST);
+        }
+
+        return posts;
+    }
+
+    // 특정일 postId 이후 post 조회
+    @Transactional
+    public List<MultiPostRes> getPostsOfDate(long userId, long familyId, int year, int month, int day, long postId) throws BaseException{
+        LocalDate date = LocalDate.of(year, month, day);
+        LocalTime dummy = LocalTime.MIDNIGHT; // LocalDateTime 변수 생성을 위한 dummy 값
+
+        LocalDateTime dateTime = LocalDateTime.of(date, dummy);
+
+        Pageable pageable = PageRequest.of(0, 10);
+        List<MultiPostRes> posts = postRepository.findByFamilyIdWithDateAfterPostId(familyId, userId, dateTime, postId, pageable);
+
+        if(posts.isEmpty()) {
+            throw new BaseException(minnie_POSTS_NON_EXISTS_POST);
+        }
+
+        return posts;
     }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 특정 일 기준 post 목록 조회
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 특정 일 기준 최신 post 조회 (10건)
- 특정 일 기준 기준 postId 이후 post 조회 (10건)
 

### 작업 후 기대 동작(스크린샷)
- 특정 일 기준 최신 post 목록 
![TalkMedia_i_b47ec1a2b311 png](https://github.com/familymoments/family-moments-BE/assets/90233522/78aef2e6-ad36-4377-b2b9-cb54fff3c918)

- 특정 일, postId 기준 이후 post 목록
 ![TalkMedia_i_ad8bbad296e2 png](https://github.com/familymoments/family-moments-BE/assets/90233522/f9f65b7d-cddb-4bd3-80da-d639d30a5c94)

