### PR TITLE
feat: 특정 월 post가 존재하는 날짜 조회

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -7,7 +7,7 @@
         <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.28/a2ff5da8bcd8b1b26f36b806ced63213362c6dcc/lombok-1.18.28.jar" />
         </processorPath>
-        <module name="com.family-moments.family-moments-server.main" />
+        <module name="family-moments-server.main" />
       </profile>
     </annotationProcessing>
   </component>

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -15,6 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -218,9 +219,29 @@ public class PostController {
     }
 
     /**
+     * 특정 월 게시물 작성일 조회 API
+     * [GET] /posts/calendar?familyId={가족인덱스}&year={년}&month={월}
+     * @return BaseResponse<List<MultiPostRes>>
+     */
+   @GetMapping(value = "/calendar", params = {"familyId", "year", "month"})
+   public BaseResponse<List<LocalDate>> getDatesExistPost(@RequestParam("familyId") long familyId, @RequestParam("year") int year, @RequestParam("month") int month) {
+       if(month < 1 || month > 12 || year > LocalDate.now().getYear()) {
+           return new BaseResponse<>(minnie_POSTS_WRONG_POST_ID);
+       }
+
+       List<LocalDate> dates = null;
+       try {
+           dates = postService.getDayExistsPost(familyId, year, month);
+           return new BaseResponse<>(dates);
+       } catch (BaseException e) {
+           return new BaseResponse<>(e.getStatus());
+       }
+   }
+
+    /**
      * 좋아요 목록 조회 API
      * [GET] /posts/{postId}/postLoves
-     * @return BaseResponse<SinglePostRes>
+     * @return BaseResponse<List<CommentRes>>
      */
     @GetMapping("/{postId}/post-loves")
     public BaseResponse<List<CommentRes>> getLovedList(@PathVariable long postId) {

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostRepository.java
@@ -74,4 +74,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     SinglePostRes findByPostId(@Param("userId") long userId, @Param("postId") long postId);
 
     Post findByPostIdAndStatus(long postId, BaseEntity.Status status);
+
+    @Query("SELECT distinct p.createdAt " +
+            "FROM Post p " +
+            "WHERE p.familyId.familyId = :familyId AND p.status = :status " +
+            "AND p.createdAt BETWEEN :startDate AND :endDate " +
+            "ORDER BY p.postId ASC ")
+    List<LocalDateTime> getDateExistPost(@Param("familyId") long familyId, @Param("status") BaseEntity.Status status, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -20,6 +20,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -196,7 +198,7 @@ public class PostService {
         return posts;
     }
 
-    // 특정일 postId 이후 post 조회
+    // 특정 일 postId 이후 post 조회
     @Transactional
     public List<MultiPostRes> getPostsOfDate(long userId, long familyId, int year, int month, int day, long postId) throws BaseException{
         LocalDate date = LocalDate.of(year, month, day);
@@ -212,5 +214,29 @@ public class PostService {
         }
 
         return posts;
+    }
+
+    @Transactional
+    public List<LocalDate> getDayExistsPost(long familyId, int year, int month) throws BaseException {
+        // date 정보 생성
+        YearMonth month_info = YearMonth.of(year, month);
+        LocalDate start_date = month_info.atDay(1);
+        LocalDate end_date = month_info.atEndOfMonth();
+        LocalDateTime start = start_date.atStartOfDay();
+        LocalDateTime end = end_date.atTime(LocalTime.MAX);
+
+        List<LocalDateTime> dateTimes = postRepository.getDateExistPost(familyId, BaseEntity.Status.ACTIVE, start, end);
+
+        if(dateTimes.isEmpty()) {
+            throw new BaseException(minnie_POSTS_NON_EXISTS_POST);
+        }
+
+        List<LocalDate> dates = new ArrayList<>();
+
+        for(LocalDateTime dateTime : dateTimes) {
+            dates.add(dateTime.toLocalDate());
+        }
+
+        return dates;
     }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 특정 월의 post가 존재하는 날짜 리스트 조회
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 특정 월의 post가 존재하는 날짜 리스트를 조회합니다. 중복값은 제외되며 오름차순으로 정렬됩니다.

### 작업 후 기대 동작(스크린샷)

- 동작
![TalkMedia_i_ccc27d01d0a4 png](https://github.com/familymoments/family-moments-BE/assets/90233522/33733dc6-add7-4a61-bb2e-e92a764f2bc0)
 

