### PR TITLE
feat: post 도메인 response 수정(LocalDateTime -> LocalDate)

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -70,7 +70,7 @@ public class PostService {
         SinglePostRes singlePostRes = SinglePostRes.builder()
                 .postId(result.getPostId())
                 .writer(result.getWriter().getNickname()).profileImg(result.getWriter().getProfileImg())
-                .content(result.getContent()).imgs(result.getImgs()).createdAt(result.getCreatedAt())
+                .content(result.getContent()).imgs(result.getImgs()).createdAt(result.getCreatedAt().toLocalDate())
                 .countLove(0).loved(false) // 새로 생성된 정보이므로 default return
                 .build();
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/model/MultiPostRes.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/model/MultiPostRes.java
@@ -1,9 +1,11 @@
 package com.spring.familymoments.domain.post.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.spring.familymoments.domain.common.BaseEntity;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -21,7 +23,9 @@ public class MultiPostRes {
     private String profileImg;
     private String content;
     private List<String> imgs;
-    private LocalDateTime createdAt;
+    @JsonIgnore
+    private LocalDateTime createdAtLocalDateTime;
+    private LocalDate createdAt;
     private Boolean loved;
 
     public MultiPostRes(Long postId, String writer, String profileImg, String content, String imgs, LocalDateTime createdAt, BaseEntity.Status status) {
@@ -30,7 +34,7 @@ public class MultiPostRes {
         this.profileImg = profileImg;
         this.content = content;
         this.imgs = Arrays.asList(imgs.split(","));
-        this.createdAt = createdAt;
+        this.createdAt = createdAt.toLocalDate();
         this.loved = status == BaseEntity.Status.ACTIVE;
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/model/SinglePostRes.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/model/SinglePostRes.java
@@ -1,7 +1,10 @@
 package com.spring.familymoments.domain.post.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import com.spring.familymoments.domain.common.BaseEntity;
 import java.util.Arrays;
@@ -19,7 +22,9 @@ public class SinglePostRes {
     private String profileImg;
     private String content;
     private List<String> imgs;
-    private LocalDateTime createdAt;
+    @JsonIgnore
+    private LocalDateTime createdAtLocalDateTime;
+    private LocalDate createdAt;
     private int countLove;
     private Boolean loved;
 
@@ -30,7 +35,7 @@ public class SinglePostRes {
         this.profileImg = profileImg;
         this.content = content;
         this.imgs = Arrays.asList(imgs.split(","));
-        this.createdAt = createdAt;
+        this.createdAt = createdAt.toLocalDate();
         this.countLove = countLove;
         this.loved = status == BaseEntity.Status.ACTIVE;
     }


### PR DESCRIPTION
post 정보 response 시 LocalDateTime이 아닌 LocalDate로 전송하도록 변경

### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : post 도메인들의 response 내역을 수정했습니다.
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- API 설계 시 time 정보를 제외하고 보내는 것으로 기획되었으나, Time 정보가 포함되어 전송되고 있었습니다.
서버 내에서 정렬된 상태로 데이터를 전송하므로, 시간 정보를 제외해도 프론트에서 문제가 발생하지 않습니다.