### PR TITLE
fix: getOnePost 시 delete 된 post 가 출력되는 문제 수정

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostRepository.java
@@ -70,7 +70,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "(p.postId, u.nickname, u.profileImg, p.content, CONCAT(COALESCE(p.img1, ''), ',', COALESCE(p.img2, ''), ',', COALESCE(p.img3, ''), ',', COALESCE(p.img4, '')), p.createdAt, p.countLove, pl.status) " +
             "FROM Post p JOIN p.writer u " +
             "LEFT JOIN PostLove pl On p = pl.postId AND pl.userId.userId = :userId " +
-            "WHERE p.postId = :postId")
+            "WHERE p.postId = :postId " +
+            "AND p.status = 'ACTIVE'")
     SinglePostRes findByPostId(@Param("userId") long userId, @Param("postId") long postId);
 
     Post findByPostIdAndStatus(long postId, BaseEntity.Status status);


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : getOnePost 시 delete된 post(INACTIVE)가 삭제 되는 문제를 수정했습니다.
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 쿼리 중 누락된'status = ACTIVE' 구문을 추가하였습니다.
