### PR TITLE
fix: 아이디/이메일 중복확인의 Method를 PostMapping으로 수정

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -111,7 +111,7 @@ public class UserController {
      * [GET] /users/check-id
      * @return BaseResponse<String>
      */
-    @GetMapping("/users/check-id")
+    @PostMapping("/users/check-id")
     public BaseResponse<String> checkDuplicateId(@RequestBody GetDuplicateUserIdReq getDuplicateUserIdReq) throws BaseException {
         try{
             if(!userService.checkDuplicateId(getDuplicateUserIdReq.getId())) {
@@ -129,7 +129,7 @@ public class UserController {
      * [GET] /users/check-email
      * @return BaseResponse<String>
      */
-    @GetMapping("/users/check-email")
+    @PostMapping("/users/check-email")
     public BaseResponse<String> checkDuplicateEmail(@RequestBody GetDuplicateUserEmailReq getDuplicateUserEmailReq) throws BaseException {
         try{
             if(!userService.checkDuplicateEmail(getDuplicateUserEmailReq.getEmail())) {


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [X] 버그 수정 : 아이디/이메일 중복확인의 Method를 `GetMapping`에서 `PostMapping`으로 수정
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 아이디/이메일 중복확인의 Method를 `GetMapping`에서 `PostMapping`으로 수정
- `Controller`의 인자가 `RequestParam`에서 `RequestBody`로 수정되었었음(#50)

### 작업 내역

- 아이디/이메일 중복확인의 Method를 `GetMapping`에서 `PostMapping`으로 수정

### 작업 후 기대 동작(스크린샷)

### PR 특이 사항

### Issue Number 

close: #

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
