### PR TITLE
fix: InternalServerException 삭제

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -61,8 +61,9 @@ public enum BaseResponseStatus {
     SERVER_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버와의 연결에 실패하였습니다."),
 
     //[GET] /users
+    FIND_FAIL_USER_ID(false,HttpStatus.NOT_FOUND.value(),"존재하지 않는 아이디입니다."),
     FIND_FAIL_USERNAME(false,HttpStatus.NOT_FOUND.value(),"가입되지 않은 회원입니다."),
-    FIND_FAIL_USER_EMAIL(false,HttpStatus.NOT_FOUND.value(),"가입되지 않은 이메일입니다."),
+    FIND_FAIL_USER_EMAIL(false,HttpStatus.NOT_FOUND.value(),"존재하지 않는 이메일입니다."),
     FIND_FAIL_USER_NAME_AND_EMAIL(false,HttpStatus.NOT_FOUND.value(), "일치하는 회원 정보가 없습니다."),
 
     //[PATCH] /users/{userIdx}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailService.java
@@ -1,7 +1,6 @@
 package com.spring.familymoments.domain.user;
 
 import com.spring.familymoments.config.BaseException;
-import com.spring.familymoments.config.advice.exception.InternalServerErrorException;
 import com.spring.familymoments.domain.user.entity.User;
 import com.spring.familymoments.domain.user.model.GetUserIdRes;
 import com.spring.familymoments.domain.user.model.PostEmailReq;
@@ -14,6 +13,8 @@ import org.springframework.stereotype.Service;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import java.util.Objects;
+
+import static com.spring.familymoments.config.BaseResponseStatus.FIND_FAIL_USER_EMAIL;
 
 @Slf4j
 @Service
@@ -101,8 +102,7 @@ public class EmailService {
 
         String userId = null;
 
-        User member = userRepository.findByEmail(req.getEmail())
-                .orElseThrow(() -> new InternalServerErrorException("가입되지 않은 이메일입니다."));
+        User member = userRepository.findByEmail(req.getEmail()).orElseThrow(() -> new BaseException(FIND_FAIL_USER_EMAIL));
 
         userId = member.getId();
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -2,7 +2,6 @@ package com.spring.familymoments.domain.user;
 
 import com.spring.familymoments.config.BaseException;
 import com.spring.familymoments.config.BaseResponse;
-import com.spring.familymoments.config.advice.exception.InternalServerErrorException;
 import com.spring.familymoments.config.secret.jwt.JwtService;
 import com.spring.familymoments.domain.awsS3.AwsS3Service;
 import com.spring.familymoments.domain.redis.RedisService;
@@ -148,7 +147,7 @@ public class UserController {
      */
     @PostMapping("/users/auth/find-id")
     public BaseResponse<GetUserIdRes> findUserId(@RequestBody PostEmailReq.sendVerificationEmail sendEmailReq)
-            throws InternalServerErrorException, MessagingException, BaseException {
+            throws MessagingException, BaseException {
 
         //이름
         if(sendEmailReq.getName() == null) {
@@ -182,7 +181,7 @@ public class UserController {
      */
     @PostMapping("/users/auth/check-id")
     public BaseResponse<String> findUserIdBeforeUpdatePwd(@RequestBody GetUserIdReq getUserIdReq)
-            throws InternalServerErrorException, MessagingException, BaseException {
+            throws MessagingException, BaseException {
         try {
             if (userService.checkDuplicateId(getUserIdReq.getUserId())) {
                 // GetUserIdRes getUserIdRes = new GetUserIdRes(id);
@@ -202,7 +201,7 @@ public class UserController {
      */
     @PostMapping("/users/auth/find-pwd")
     public BaseResponse<String> findUserPwd(@RequestBody PostEmailReq.sendVerificationEmail sendEmailReq)
-            throws InternalServerErrorException, MessagingException, BaseException {
+            throws MessagingException, BaseException {
 
         //이름
         if(sendEmailReq.getName() == null) {
@@ -221,9 +220,9 @@ public class UserController {
                 GetUserIdRes getUserIdRes = emailService.findUserId(sendEmailReq);
                 return new BaseResponse<String>("이메일이 인증되었습니다. 새로운 비밀번호를 입력해주세요.");
             } else if(emailService.checkVerificationCode(sendEmailReq) && !emailService.checkNameAndEmail(sendEmailReq)) {
-                return new BaseResponse<>(FIND_FAIL_USER_NAME_EMAIL);
+                return new BaseResponse<>(false, FIND_FAIL_USER_NAME_EMAIL.getMessage(), HttpStatus.NOT_FOUND.value());
             } else {
-                return new BaseResponse<>(NOT_EQUAL_VERIFICATION_CODE);
+                return new BaseResponse<>(false, NOT_EQUAL_VERIFICATION_CODE.getMessage(), HttpStatus.BAD_REQUEST.value());
             }
         } catch (NoSuchElementException e) {
             return new BaseResponse<>(false, e.getMessage(), HttpStatus.NOT_FOUND.value());
@@ -394,23 +393,32 @@ public class UserController {
     @Transactional
     @PatchMapping("/users/auth/modify-pwd")
     public BaseResponse<String> updatePasswordWithoutLogin(@RequestBody PatchPwdWithoutLoginReq patchPwdWithoutLoginReq,
-                                                           @RequestParam String id) {
+                                                           @RequestParam String id) throws BaseException{
 
-        String memberEmail = emailService.getUserId(id);
+        String memberId = emailService.getUserId(id);
 
-        if(!isRegexPw(patchPwdWithoutLoginReq.getPasswordA())) {
-            return new BaseResponse<>(POST_USERS_INVALID_PW);
+        try {
+            if(userService.checkDuplicateId(memberId)) {
+                if(!isRegexPw(patchPwdWithoutLoginReq.getPasswordA())) {
+                    return new BaseResponse<>(POST_USERS_INVALID_PW);
+                }
+                if(patchPwdWithoutLoginReq.getPasswordB() == "") {
+                    return new BaseResponse<>(EMPTY_PASSWORD);
+                }
+                if(!patchPwdWithoutLoginReq.getPasswordA().equals(patchPwdWithoutLoginReq.getPasswordB())) {
+                    return new BaseResponse<>(NOT_EQUAL_NEW_PASSWORD);
+                }
+
+                userService.updatePasswordWithoutLogin(patchPwdWithoutLoginReq, memberId);
+
+                return new BaseResponse<>("비밀번호가 변경되었습니다. 다시 로그인을 진행해주세요.");
+            } else {
+                return new BaseResponse<>(false, FIND_FAIL_USER_ID.getMessage(), HttpStatus.NOT_FOUND.value());
+            }
+        } catch (NoSuchElementException e) {
+            return new BaseResponse<>(false, e.getMessage(), HttpStatus.NOT_FOUND.value());
         }
-        if(patchPwdWithoutLoginReq.getPasswordB() == "") {
-            return new BaseResponse<>(EMPTY_PASSWORD);
-        }
-        if(!patchPwdWithoutLoginReq.getPasswordA().equals(patchPwdWithoutLoginReq.getPasswordB())) {
-            return new BaseResponse<>(NOT_EQUAL_NEW_PASSWORD);
-        }
 
-        userService.updatePasswordWithoutLogin(patchPwdWithoutLoginReq, memberEmail);
-
-        return new BaseResponse<>("비밀번호가 변경되었습니다. 다시 로그인을 진행해주세요.");
     }
 
     /**

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -1,7 +1,6 @@
 package com.spring.familymoments.domain.user;
 
 import com.spring.familymoments.config.BaseException;
-import com.spring.familymoments.config.advice.exception.InternalServerErrorException;
 import com.spring.familymoments.config.secret.jwt.JwtService;
 import com.spring.familymoments.domain.comment.CommentWithUserRepository;
 import com.spring.familymoments.domain.comment.entity.Comment;
@@ -249,9 +248,8 @@ public class UserService {
      * [PATCH]
      * @return
      */
-    public void updatePasswordWithoutLogin(PatchPwdWithoutLoginReq patchPwdWithoutLoginReq, String id) {
-        User user = userRepository.findById(id)
-                .orElseThrow(() -> new InternalServerErrorException("아이디가 일치하지 않습니다."));
+    public void updatePasswordWithoutLogin(PatchPwdWithoutLoginReq patchPwdWithoutLoginReq, String id) throws BaseException {
+        User user = userRepository.findById(id).orElseThrow(() -> new BaseException(FIND_FAIL_USER_ID));
 
         user.updatePassword(passwordEncoder.encode(patchPwdWithoutLoginReq.getPasswordA()));
         userRepository.save(user);


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [X] 리펙토링 : 남아있던 `InternalServerException` 삭제
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 비밀번호 재설정(로그인 없이 진행) 관련 `Service`의 `.orElseThrow()` 코드 
- 이유: 예외처리 형식을 맞추기 위해서 수정했습니다.

### 작업 내역

- 비밀번호 재설정(로그인 없이 진행) 관련 `Service`의 `.orElseThrow()` 코드 

### 작업 후 기대 동작(스크린샷)

- 명세서에 작성했습니다.

### PR 특이 사항

- #37, #40, #41
- `InternalServerException`을 없애고, `Controller`에 `try-catch`를 추가했다는 점에서 위 PR들과 비슷합니다.

### Issue Number 

close: #

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
