### PR TITLE
feat: 앨범의 상세 페이지 api

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -80,7 +80,7 @@ public enum BaseResponseStatus {
 
 
     minnie_POSTS_INVALIED_USER(false, HttpStatus.FORBIDDEN.value(), "수정 권한이 없습니다."),
-    minnie_POSTS_WRONG_POST_ID(false, HttpStatus.NOT_FOUND.value(), "유효하지 않은 postId 입니다."),
+    minnie_POSTS_INVALIED_POST_ID(false, HttpStatus.NOT_FOUND.value(), "유효하지 않은 postId 입니다."),
     minnie_POSTS_NON_EXISTS_POST(false, HttpStatus.NOT_FOUND.value(), "post가 존재하지 않습니다."),
     minnie_POSTS_EMPTY_UPDATE(false, HttpStatus.BAD_REQUEST.value(), "수정할 내용을 보내주세요."),
     minnie_POSTS_EMPTY_CONTENT(false, HttpStatus.BAD_REQUEST.value(), "내용을 입력해주세요."),

--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -79,8 +79,8 @@ public enum BaseResponseStatus {
     ALREADY_DELETE_COMMENT(false, HttpStatus.NOT_FOUND.value(), "이미 삭제된 댓글입니다."),
 
 
-    minnie_POSTS_INVALIED_USER(false, HttpStatus.FORBIDDEN.value(), "수정 권한이 없습니다."),
-    minnie_POSTS_INVALIED_POST_ID(false, HttpStatus.NOT_FOUND.value(), "유효하지 않은 postId 입니다."),
+    minnie_POSTS_INVALID_USER(false, HttpStatus.FORBIDDEN.value(), "수정 권한이 없습니다."),
+    minnie_POSTS_INVALID_POST_ID(false, HttpStatus.NOT_FOUND.value(), "유효하지 않은 postId 입니다."),
     minnie_POSTS_NON_EXISTS_POST(false, HttpStatus.NOT_FOUND.value(), "post가 존재하지 않습니다."),
     minnie_POSTS_EMPTY_UPDATE(false, HttpStatus.BAD_REQUEST.value(), "수정할 내용을 보내주세요."),
     minnie_POSTS_EMPTY_CONTENT(false, HttpStatus.BAD_REQUEST.value(), "내용을 입력해주세요."),

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -293,7 +293,7 @@ public class PostController {
        }
 
        if(month < 1 || month > 12 || year > LocalDate.now().getYear()) {
-           return new BaseResponse<>(minnie_POSTS_INVALIED_POST_ID);
+           return new BaseResponse<>(minnie_POSTS_INVALID_POST_ID);
        }
 
        List<LocalDate> dates = null;

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -293,7 +293,7 @@ public class PostController {
        }
 
        if(month < 1 || month > 12 || year > LocalDate.now().getYear()) {
-           return new BaseResponse<>(minnie_POSTS_WRONG_POST_ID);
+           return new BaseResponse<>(minnie_POSTS_INVALIED_POST_ID);
        }
 
        List<LocalDate> dates = null;
@@ -342,6 +342,26 @@ public class PostController {
             return new BaseResponse<>(e.getStatus());
         }
     }
+
+    /**
+     * 앨범 상세 조회 API
+     * [GET] /posts/album/{post인덱스}
+     * @return BaseResponse<List<String>>
+     */
+    @GetMapping(value = "/album/{postId}")
+    public BaseResponse<List<String>> getAlbumImages(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
+        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
+            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
+        }
+
+        try {
+            List<String> imgs = postService.getPostImages(postId);
+            return new BaseResponse<>(imgs);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
 
     /**
      * 좋아요 목록 조회 API

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -26,6 +26,7 @@ import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.spring.familymoments.config.BaseResponseStatus.*;
 
@@ -181,7 +182,7 @@ public class PostService {
         SinglePostRes singlePostRes = postRepository.findByPostId(userId, postId);
 
         if(singlePostRes == null) {
-            throw new BaseException(minnie_POSTS_WRONG_POST_ID);
+            throw new BaseException(minnie_POSTS_INVALIED_POST_ID);
         }
 
         return singlePostRes;
@@ -281,5 +282,14 @@ public class PostService {
         }
 
         return albumResList;
+    }
+
+    @Transactional
+    public List<String> getPostImages(long postId) throws BaseException {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new BaseException(minnie_POSTS_INVALIED_POST_ID));
+
+        List<String> imgs = post.getImgs();
+        
+        return imgs;
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -26,7 +26,6 @@ import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import static com.spring.familymoments.config.BaseResponseStatus.*;
 
@@ -95,7 +94,7 @@ public class PostService {
         }
 
         if(!Objects.equals(editedPost.getWriter().getUserId(), user.getUserId())) {
-            throw new BaseException(minnie_POSTS_INVALIED_USER);
+            throw new BaseException(minnie_POSTS_INVALID_USER);
         }
 
         SinglePostRes singlePostRes = getPost(user.getUserId(), postId);
@@ -142,7 +141,7 @@ public class PostService {
         }
 
         if(!deletedPost.getWriter().getUserId().equals(user.getUserId())) {
-            throw new BaseException(minnie_POSTS_INVALIED_USER);
+            throw new BaseException(minnie_POSTS_INVALID_USER);
         }
 
         deletedPost.delete();
@@ -182,7 +181,7 @@ public class PostService {
         SinglePostRes singlePostRes = postRepository.findByPostId(userId, postId);
 
         if(singlePostRes == null) {
-            throw new BaseException(minnie_POSTS_INVALIED_POST_ID);
+            throw new BaseException(minnie_POSTS_INVALID_POST_ID);
         }
 
         return singlePostRes;
@@ -286,10 +285,10 @@ public class PostService {
 
     @Transactional
     public List<String> getPostImages(long postId) throws BaseException {
-        Post post = postRepository.findById(postId).orElseThrow(() -> new BaseException(minnie_POSTS_INVALIED_POST_ID));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new BaseException(minnie_POSTS_INVALID_POST_ID));
 
         List<String> imgs = post.getImgs();
-        
+
         return imgs;
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveService.java
@@ -86,7 +86,7 @@ public class PostLoveService {
         Post post = postRepository.findByPostIdAndStatus(postId, BaseEntity.Status.ACTIVE);
 
         if(post == null) {
-            throw new BaseException(minnie_POSTS_WRONG_POST_ID);
+            throw new BaseException(minnie_POSTS_INVALIED_POST_ID);
         }
 
         List<CommentRes> users = postLoveRepository.findByPost(post);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveService.java
@@ -86,7 +86,7 @@ public class PostLoveService {
         Post post = postRepository.findByPostIdAndStatus(postId, BaseEntity.Status.ACTIVE);
 
         if(post == null) {
-            throw new BaseException(minnie_POSTS_INVALIED_POST_ID);
+            throw new BaseException(minnie_POSTS_INVALID_POST_ID);
         }
 
         List<CommentRes> users = postLoveRepository.findByPost(post);


### PR DESCRIPTION
### 무엇을 위한 PR인가요?

- [x] 신규 기능 추가 : 앨범의 상세 게시물 api 추가
- [ ] 버그 수정 :
- [x] 리펙토링 : BaseResponseStatus 중 오타 수정
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- FE의 브이엘이 요청한 앨범의 상세 페이지 조회 api를 추가하였습니다.
postId를 통해 이미지 리스트를 return하는 api입니다. 
![image](https://github.com/familymoments/family-moments-BE/assets/90233522/e2f10492-921b-433a-b84f-f210009e766d)
    - 요청서 (https://www.notion.so/API-c5442a4f509f497582f2c49c93499631?pvs=4)
    - API Sheet (https://www.notion.so/55a0f64db5fa475fad23b0812c7ddd00?pvs=4)
- BaseResponseStatus 중 minnie_POSTS_INVAIED_…를 minnie_POSTS_INVALID_…로 변경하였습니다.

### 작업 후 기대 동작(스크린샷)

- 동작
![image](https://github.com/familymoments/family-moments-BE/assets/90233522/ef824688-29dd-4623-9b75-e437be4ee342)
