### PR TITLE
fix : image 수 변동 시 out of index 에러 수정, img1만 갱신되던 에러 수정

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -98,35 +98,48 @@ public class PostService {
         }
 
         SinglePostRes singlePostRes = getPost(user.getUserId(), postId);
+        ArrayList resImgs = new ArrayList<>(singlePostRes.getImgs());
 
         if(postReq.getContent() != null) {
             singlePostRes.setContent(postReq.getContent());
             editedPost.updateContent(singlePostRes.getContent());
         }
 
-        for(int i = 0 ; i < postReq.getImgs().size(); i++) {
-            if(postReq.getImgs().get(i) != null) {
+        for(int i = 0 ; i < 4; i++) {
+            String url;
+
+            if(postReq.getImgs().size() > i && postReq.getImgs().get(i) != null) {
                 MultipartFile img = postReq.getImgs().get(i);
-                String url = awsS3Service.uploadImage(img);
-                singlePostRes.getImgs().set(i, url);
-                switch(i) {
-                    case 0:
-                        editedPost.updateImg1(url);
-                        break;
-                    case 1:
-                        editedPost.updateImg2(url);
-                        break;
-                    case 2:
-                        editedPost.updateImg3(url);
-                        break;
-                    case 3:
-                        editedPost.updateImg4(url);
-                        break;
-                    default:
-                        break;
-                }
+                url = awsS3Service.uploadImage(img);
+            } else {
+                url = null;
+            }
+
+            if(resImgs.size() - 1 < i) {
+                resImgs.add(url);
+            } else {
+                resImgs.set(i, url);
+            }
+
+            switch(i) {
+                case 0:
+                    editedPost.updateImg1(url);
+                    break;
+                case 1:
+                    editedPost.updateImg2(url);
+                    break;
+                case 2:
+                    editedPost.updateImg3(url);
+                    break;
+                case 3:
+                    editedPost.updateImg4(url);
+                    break;
+                default:
+                    break;
             }
         }
+
+        singlePostRes.setImgs(resImgs);
 
         return singlePostRes;
     }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/Post.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/Post.java
@@ -83,15 +83,15 @@ public class Post extends BaseEntity {
     }
 
     public void updateImg2(String newImg) {
-        this.img1 = newImg;
+        this.img2 = newImg;
     }
 
     public void updateImg3(String newImg) {
-        this.img1 = newImg;
+        this.img3 = newImg;
     }
 
     public void updateImg4(String newImg) {
-        this.img1 = newImg;
+        this.img4 = newImg;
     }
 
     public void delete() {


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : image 수 변동 시 발생하는 에러 수정하였습니다.
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- image 수정 시 이미지 개수가 늘거나(out of index error), 줄어들 때 (반영 안 됨) 이슈가 있었습니다.
- 추가로, Post Entity의 구문 에러로 img1의 url만 갱신되던 문제가 있었습니다.

### PR 특이 사항

- 차후 프론트엔드에서의 form-data patch 사용 불가 연락 시 변동될 수 있습니다.


