### PR TITLE
Fix : 회원정보수정, 비밀번호변경 API 오타 및 예외처리 수정 

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -375,30 +375,30 @@ public class UserController {
     public BaseResponse<String> updatePassword(@RequestBody PatchPwdReq patchPwdReq,
                                                @AuthenticationPrincipal User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken) {
         if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
+            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨. -> 461
         }
         if(user == null) {
             return new BaseResponse<>(INVALID_USER_JWT); //403 error : 유효한 사용자가 아님.
         }
         //비밀번호 변경
         if(!authenticate(new GetPwdReq(patchPwdReq.getPassword()), user, requestAccessToken).getIsSuccess()) { //비밀번호 인증
-            return new BaseResponse<>(FAILED_AUTHENTICATION);
+            return new BaseResponse<>(false, "비밀번호가 올바르지 않습니다.", 4000); //<- 403
         }
         //새 비밀번호 빈 입력
         if(patchPwdReq.getNewPassword_first().isEmpty() || patchPwdReq.getNewPassword().isEmpty()) {
-            return new BaseResponse<>(EMPTY_PASSWORD);
+            return new BaseResponse<>(false, "비밀번호를 입력하세요.", 4001); //<- 400 EMPTY_PASSWORD
         }
         //새 비밀번호 재확인
         if(!patchPwdReq.getNewPassword_first().equals(patchPwdReq.getNewPassword())) {
-            return new BaseResponse<>(false, "새 비밀번호가 일치하지 않습니다.", 400);
+            return new BaseResponse<>(false, "새 비밀번호가 일치하지 않습니다.", 4002); //<- 400
         }
         //기존 비밀번호와 새 비밀번호 일치
         if(patchPwdReq.getPassword().equals(patchPwdReq.getNewPassword())) {
-            return new BaseResponse<>(EQUAL_NEW_PASSWORD);
+            return new BaseResponse<>(false, "기존 비밀번호와 같습니다.", 4003); //<- 400 EQUAL_NEW_PASSWORD
         }
         //새 비밀번호 형식
         if(!isRegexPw(patchPwdReq.getNewPassword())) {
-            return new BaseResponse<>(POST_USERS_INVALID_PW);
+            return new BaseResponse<>(false, "비밀번호 형식을 확인해주세요.", 4004); //<- 400 POST_USERS_INVALID_PW
         }
         userService.updatePassword(patchPwdReq, user);
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PatchPwdReq.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PatchPwdReq.java
@@ -11,5 +11,6 @@ import lombok.Setter;
 @AllArgsConstructor
 public class PatchPwdReq {
     private String password;
+    private String newPassword_first;
     private String newPassword;
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 회원정보수정 API _ 오타 수정 RequestParam -> Resquest**Part** 😂
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [x] 기타 : 비밀번호 변경 API 예외처리 (새비밀번호재확인추가 및 에러코드(4000~4004) 변경)

### 변경사항 및 이유
1. 회원정보수정API (Patch 관련 API) - 프론트분과 계속 소통하며 로그를 확인하다가 RequestPart가 Missing 된다는 것을 확인했다. 그 이후에 내 코드를 자세히 살펴보니... RequestPart가 아닌 RequestParam으로 오타가 나있는 것을 확인했다.  (postman은 왜 괜찮았는지 의문)

2. 비밀번호 변경 예외처리 
  2-1. 새비밀번호 재확인 예외처리를 추가했다.
  2-2. 프론트 요청을 받아 원래 **400번으로** 통일되었던 에러 코드 번호를 **4000~4004로** 분리해서 새로 설정했다. 관련 문서를 찾 
  아본 결과 프론트와 원활한 소통을 위해서 Custom한 Error Code가 필요하다는 사실을 확인해서 아래와 같이 변경했다.

### 작업 후 기대 동작(스크린샷)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/4e8c3f2f-ae78-46a9-a9c8-bfaafe887c31)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/d32529e0-0648-4b04-b918-715e0151086a)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/c7da636e-14b0-4792-90c6-df726c0c3c82)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/77088e96-10d8-4978-8fba-46b98d40896d)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/6510dcca-17d9-4075-86e5-2203cebd66b2)

### Issue Number 

close: #74

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 에러 코드 번호를 임의로 4000~4004로 설정했는데 이 부분에 관해 어떻게 생각하시는 지 의견 듣고 싶습니다!
