### PR TITLE
fix : PATCH to POST

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -89,11 +89,11 @@ public class PostController {
 
     /**
      * 게시글 수정 API
-     * [PATCH] /posts?{postId}
+     * [POST] /posts/{postId}/edit
      * @return BaseResponse<SinglePostRes>
      */
     @ResponseBody
-    @PatchMapping("/{postId}")
+    @PostMapping("/{postId}/edit")
     public BaseResponse<SinglePostRes> editPost(@AuthenticationPrincipal User user,
                                                 @RequestHeader("X-AUTH-TOKEN") String requestAccessToken,
                                                 @PathVariable long postId,

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -98,7 +98,7 @@ public class PostService {
         }
 
         SinglePostRes singlePostRes = getPost(user.getUserId(), postId);
-        ArrayList resImgs = new ArrayList<>(singlePostRes.getImgs());
+        ArrayList resImgs = new ArrayList<String>();
 
         if(postReq.getContent() != null) {
             singlePostRes.setContent(postReq.getContent());
@@ -115,10 +115,8 @@ public class PostService {
                 url = null;
             }
 
-            if(resImgs.size() - 1 < i) {
+            if(url != null) {
                 resImgs.add(url);
-            } else {
-                resImgs.set(i, url);
             }
 
             switch(i) {

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -303,13 +303,13 @@ public class UserController {
     }
     /**
      * 회원 정보 수정 API
-     * [PATCH] /users
+     * [POST] /users/edit
      * @param profileImg
      * @return BaseResponse<PatchProfileReqRes>
      */
-    @PatchMapping("/users")
+    @PostMapping("/users/edit")
     public BaseResponse<PatchProfileReqRes> updateProfile(@RequestPart(name = "profileImg") MultipartFile profileImg,
-                                                          @RequestPart PatchProfileReqRes patchProfileReqRes,
+                                                          @RequestPart(name = "PatchProfileReqRes") PatchProfileReqRes patchProfileReqRes,
                                                           @AuthenticationPrincipal User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken) throws BaseException {
         if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
             return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -341,10 +341,10 @@ public class UserController {
     }
     /**
      * 비밀번호 인증 API
-     * [GET] /users/auth/compare-pwd
+     * [POST] /users/auth/compare-pwd
      * @return BaseResponse<String>
      */
-    @GetMapping("/users/auth/compare-pwd")
+    @PostMapping("/users/auth/compare-pwd")
     public BaseResponse<String> authenticate(@RequestBody GetPwdReq getPwdReq,
                                              @AuthenticationPrincipal User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken) {
         if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 
    - form-data 사용 시 PATCH method에서 오류 확인. PATCH → POST method변경
    - 비밀번호 인증 API를 GET method → POST method 변경
    - Post 수정 결과 return 시 img array 중 의도하지 않은 null 리턴 이슈 수정
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- User 도메인 중 비밀번호 인증 API가 requestbody를 요청하나, GET으로 설계되어 있어 이를 POST로 수정하였습니다. (@spacewalk00)

- Postman 등 API 테스트 툴에서는 문제가 되지 않았으나,
프론트 연동 시 Patch method에 form-data 사용하는 경우(User domain 및 Post domain) 에러가 발생하는 이슈가 있었습니다. 
일차적으로 image/png, application/json을 각각 Content-type으로 받는 API 2개로 분리를 고려하였으나,
데모데이까지의 시간(프론트에서의 작업 변겅)을 고려하여 POST로 Method를 변경했습니다.
    - 해당 과정 중 User API의 경우 RequestPart 중 일부가 name 지정이 누락되어 에러가 발생, name을 명시하였습니다. (UserController, 312 Line)

- Post 수정 결과 return 시 img array 배열이 ["url1", "url2", null, null] 등으로 return 되는 것을 확인,
치명적인 이슈는 아니지만 의도했던 결과가 아니기에 수정하였습니다.


### 어떤 부분에 리뷰어가 집중하면 좋을까요?
@spacewalk00 User 부분 더블체크 부탁드립니다!