### PR TITLE
Feature/profile edit

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -308,7 +308,7 @@ public class UserController {
      * @return BaseResponse<PatchProfileReqRes>
      */
     @PostMapping("/users/edit")
-    public BaseResponse<PatchProfileReqRes> updateProfile(@RequestPart(name = "profileImg") MultipartFile profileImg,
+    public BaseResponse<PatchProfileReqRes> updateProfile(@RequestPart(name = "profileImg", required = false) MultipartFile profileImg,
                                                           @RequestPart(name = "PatchProfileReqRes") PatchProfileReqRes patchProfileReqRes,
                                                           @AuthenticationPrincipal User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken) throws BaseException {
         if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
@@ -317,9 +317,12 @@ public class UserController {
         if(user == null) {
             return new BaseResponse<>(INVALID_USER_JWT); //403 error : 유효한 사용자가 아님.
         }
-        String fileUrl = awsS3Service.uploadImage(profileImg);
-        patchProfileReqRes.setProfileImg(fileUrl);
-
+        if(profileImg == null || profileImg.isEmpty()) { //이미지 비어있으면 원래 이미지 넣어주기
+            patchProfileReqRes.setProfileImg(user.getProfileImg());
+        } else {
+            String fileUrl = awsS3Service.uploadImage(profileImg);
+            patchProfileReqRes.setProfileImg(fileUrl);
+        }
         if(patchProfileReqRes.getName() == null || patchProfileReqRes.getName().isEmpty()) { //이름 비어있으면
             return new BaseResponse<>(POST_USERS_EMPTY_NAME);
         }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 회원정보 수정 api -> 프론트에서 이미지 보내지 않을 때, 기존 회원의 이미지 넣어주는 것으로 수정
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 500 에러 해결

### 작업 내역

- usercontroller에서 profile empty일 때 기존 이미지 세팅

### 작업 후 기대 동작(스크린샷)

- 동작은 동일 : 아래 그림 postman select에서 이미지 넣어주지 않을 때 기존 이미지 파일 세팅
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/c5db7fab-f8ba-4465-92a9-c0dbf9a80d78)


### Issue Number 

close: #74 