### PR TITLE
fix : 회원탈퇴 api - param annotation 추가

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentWithUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentWithUserRepository.java
@@ -4,6 +4,7 @@ import com.spring.familymoments.domain.comment.entity.Comment;
 import com.spring.familymoments.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +14,7 @@ public interface CommentWithUserRepository extends JpaRepository<Comment, Long> 
 
     //유저가 쓴 모든 댓글들 조회
     @Query("SELECT c FROM Comment c WHERE c.writer.userId = :userId")
-    List<Comment> findCommentsByUserId(Long userId);
+    List<Comment> findCommentsByUserId(@Param("userId") Long userId);
 
     @Query("SELECT c FROM Comment c WHERE c.postId IN (SELECT p FROM Post p WHERE p.writer.userId = :userId)")
     List<Comment> findByPostUserID(Long userId);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/commentLove/CommentLoveWithUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/commentLove/CommentLoveWithUserRepository.java
@@ -3,6 +3,7 @@ package com.spring.familymoments.domain.commentLove;
 import com.spring.familymoments.domain.commentLove.entity.CommentLove;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,7 +11,7 @@ import java.util.List;
 @Repository
 public interface CommentLoveWithUserRepository extends JpaRepository<CommentLove, Long> {
     @Query("SELECT cl FROM CommentLove cl WHERE cl.userId.userId = :userId")
-    List<CommentLove> findCommentLovesByUserId(Long userId);
+    List<CommentLove> findCommentLovesByUserId(@Param("userId") Long userId);
     @Query("SELECT cl FROM CommentLove cl WHERE cl.commentId IN (SELECT c FROM Comment c WHERE c.postId IN (SELECT p FROM Post p WHERE p.writer.userId = :userId))")
     List<CommentLove> findCommentLovesByCommentUserId(Long userId);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
@@ -25,7 +25,7 @@ public interface UserFamilyRepository extends JpaRepository<UserFamily, Long> {
 
     //회원 탈퇴 시, UserFamily 매핑 테이블 해제를 위한 조회
     @Query("SELECT uf FROM UserFamily uf WHERE uf.userId.userId = :userId")
-    List<UserFamily> findUserFamilyByUserId(Long userId);
+    List<UserFamily> findUserFamilyByUserId(@Param("userId") Long userId);
 
     @Query("SELECT u FROM User u " +
             "INNER JOIN UserFamily m ON u.userId = m.userId.userId " +

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithUserRepository.java
@@ -6,6 +6,7 @@ import com.spring.familymoments.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,7 +17,7 @@ public interface PostWithUserRepository extends JpaRepository<Post, Long> {
     Long countByWriterAndFamilyId(User user, Family family);
     //유저가 작성한 모든 게시글 조회
     @Query("SELECT p FROM Post p WHERE p.writer.userId = :userId")
-    List<Post> findPostByUserId(Long userId);
+    List<Post> findPostByUserId(@Param("userId")Long userId);
 
     // 가족 내에 속한 모든 게시글 조회
     List<Post> findByFamilyId(Family family);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveRepository.java
@@ -6,6 +6,7 @@ import com.spring.familymoments.domain.user.entity.User;
 import com.spring.familymoments.domain.user.model.CommentRes;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -26,7 +27,7 @@ public interface PostLoveRepository extends JpaRepository<PostLove, Long> {
     boolean existsByPostIdAndUserId(Post post, User user);
 
     @Query("SELECT pl FROM PostLove pl WHERE pl.userId.userId = :userId")
-    List<PostLove> findPostLovesByUserId(Long userId);
+    List<PostLove> findPostLovesByUserId(@Param("userId") Long userId);
     @Query("SELECT pl FROM PostLove pl WHERE pl.postId IN (SELECT p FROM Post p WHERE p.writer.userId = :userId)")
     List<PostLove> findPostLovesByPostUserId(Long userId);
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : jpql 속 @Param 추가
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 제 개인 로컬에서는 명시적인 **param 어노테이션** 없이 작동이 잘 되었는데 다른 팀원의 로컬 환경에서 에러 메세지가 나타난다는 것을 전달 받고 수정했습니다!
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/7f237c5c-eb35-42c7-a8fe-9b18575ae7c4)
- jpa로 Query 작성할 때 파라미터 작성 시 메소드 파리미터 앞에 @Param("")을 명시적으로 해주어야 한다는 점 알아갑니다~
### Issue Number 

close: #66 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
