### PR TITLE
Fix : Feature/user edit - name updatable

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/entity/User.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/entity/User.java
@@ -50,7 +50,7 @@ public class User extends BaseTime implements UserDetails {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String password;
 
-    @Column(nullable = false, updatable = false, length = 20)
+    @Column(nullable = false, length = 20)
     private String name;
 
     @Column(nullable = false, length = 20)


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : User entity name 칼럼의 updatable=false 삭제
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 회원 정보 수정시 이름만 수정이 안됐습니다. 

### 작업 내역

- 그 원인이었던 User entity name 칼럼 옵션 updatable=false를 지웠습니다!

### 작업 후 기대 동작(스크린샷)
 회원 정보 수정 api 실행 후 회원정보 조회 api 실행 시 결과 화면입니다! (== 이름이 잘 수정이 된다) 
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/25863f8e-9065-4a60-923d-b811a54cc60c)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/b856d99d-6df8-48d4-b745-e01c22ca7c5a)
 

### PR 특이 사항

- entity 내용 수정이더라도 jpa 관련 내용이기 때문에 db를 갱신할 필요가 없습니다!

### Issue Number 

close: #91 