### PR TITLE
Fix : login api - familyId 반환 추가

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
@@ -3,6 +3,8 @@ package com.spring.familymoments.domain.common;
 import com.spring.familymoments.domain.common.entity.UserFamily;
 import com.spring.familymoments.domain.family.entity.Family;
 import com.spring.familymoments.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +16,8 @@ import java.util.Optional;
 public interface UserFamilyRepository extends JpaRepository<UserFamily, Long> {
 
     Optional<UserFamily> findByUserId(Optional<User> user);
+    @Query("SELECT uf FROM UserFamily uf WHERE uf.status = 'ACTIVE' AND uf.userId.id = :userId ORDER BY uf.createdAt ASC")
+    List<UserFamily> findFirstActiveUserFamilyByUserId(@Param("userId") String userId, Pageable pageable);
 
     List<UserFamily> findUserFamilyByUserId(Optional<User> user);
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthService.java
@@ -2,11 +2,15 @@ package com.spring.familymoments.domain.user;
 
 import com.spring.familymoments.config.secret.jwt.JwtService;
 import com.spring.familymoments.config.secret.jwt.model.TokenDto;
+import com.spring.familymoments.domain.common.UserFamilyRepository;
+import com.spring.familymoments.domain.common.entity.UserFamily;
 import com.spring.familymoments.domain.redis.RedisService;
 import com.spring.familymoments.domain.user.entity.User;
 import com.spring.familymoments.domain.user.model.PostLoginReq;
+import com.spring.familymoments.domain.user.model.PostLoginRes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -16,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
@@ -29,6 +34,7 @@ import java.util.NoSuchElementException;
 @RequiredArgsConstructor
 public class AuthService {
     private final UserRepository userRepository;
+    private final UserFamilyRepository userFamilyRepository;
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
@@ -55,6 +61,16 @@ public class AuthService {
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         return generateToken(SERVER, authentication.getName());
+    }
+    /**
+     * 로그인 시 familyId 전달
+     */
+    public PostLoginRes login_familyId(String id) {
+        List<UserFamily> userFamilyList = userFamilyRepository.findFirstActiveUserFamilyByUserId(id, PageRequest.of(0,1));
+        if(userFamilyList.size() == 0) {
+            throw new IllegalArgumentException("가입한 가족이 없습니다.");
+        }
+        return new PostLoginRes(userFamilyList.get(0).getFamilyId().getFamilyId());
     }
     /**
      * 재발급 필요 여부 확인

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/entity/User.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/entity/User.java
@@ -50,7 +50,7 @@ public class User extends BaseTime implements UserDetails {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String password;
 
-    @Column(nullable = false, updatable = false, length = 20)
+    @Column(nullable = false, length = 20)
     private String name;
 
     @Column(nullable = false, length = 20)

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostLoginRes.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostLoginRes.java
@@ -10,6 +10,5 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostLoginRes {
-    private String userId;
-    //private String jwtToken;
+    private Long familyId;
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [x] 기타 : 로그인 api에서 familyId 값 반환

### 작업 후 기대 동작(스크린샷)
- userfamily 테이블에서 가장 오래 전에 생성됐던 하나의 튜플에서  status가 active인 userfamily의 familyId를 추출해냅니다!
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/7edbd424-6dbf-406d-9199-962d0789a869)
- 가입한 family가 없을 경우, null을 반환합니다!
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/5729551e-29e8-49b6-935e-8a5b51b74ea3)


### PR 특이 사항
1. 구현 특이사항
- db 안에 여러 가족들이 존재하는 것을 고려해서 구현했습니다! 
- 데모데이 때는 db 안에 family가 한 가족만 존재할 수 있게 db 안 데이터 정리가 필요합니다!

2. commit 특이사항 - **"로그인 api -familyId 추가" 관련 커밋 확인해주시면 됩니다!! (위에서 3번째 commit)**
- 오류가 없는 줄 알고 pull request를 이전에 한번 보냈다가 오류가 존재해서 닫았습니다.!
- commit을 돌렸음에도 원격 레포지토리에 관련 내용이 이미 담겨져 있는데 pull를 하는 바람에
- 이전 내용이 commit에 포함되어있습니다! 😂 참고해주세요!

### Issue Number 

close: #61 
