### PR TITLE
Feat : [post] - swagger setting, Error Handler

### DIFF
--- a/family-moments/build.gradle
+++ b/family-moments/build.gradle
@@ -49,7 +49,13 @@ dependencies {
 	// Mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	// Random Code
-	implementation 'org.apache.commons:commons-lang3:3.0'
+	implementation 'org.apache.commons:commons-lang3:3.12.0'
+	// jsch 라이브러리, for ssh tunneling
+	implementation 'com.github.mwiede:jsch:0.2.12'
+	// application.yml의 변수 사용을 위한 라이브러리
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
 }
 
 tasks.named('test') {

--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -91,6 +91,7 @@ public enum BaseResponseStatus {
     minnie_POSTS_EMPTY_POST_INFO(false, HttpStatus.BAD_REQUEST.value(), "postInfo가 포함되어야 합니다."),
     minnie_POST_SAVE_FAIL(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "게시물 저장에 실패했습니다."),
     minnie_POSTLOVES_NON_EXISTS_LOVE(false, HttpStatus.NOT_FOUND.value(), "좋아요가 존재하지 않습니다."),
+    minnie_FAMILY_INVALID_USER(false, HttpStatus.FORBIDDEN.value(), "해당 가족의 멤버가 아닙니다"),
 
     POSTLOVE_ALREADY_EXISTS(false, HttpStatus.BAD_REQUEST.value(), "이미 좋아요를 누른 게시물입니다."),
     FIND_FAIL_POSTLOVE(false, HttpStatus.NOT_FOUND.value(), "좋아요를 누르지 않아 취소할 수 없습니다."),

--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -89,6 +89,7 @@ public enum BaseResponseStatus {
     minnie_POSTS_EMPTY_CONTENT(false, HttpStatus.BAD_REQUEST.value(), "내용을 입력해주세요."),
     minnie_POSTS_EMPTY_IMAGE(false, HttpStatus.BAD_REQUEST.value(), "img1에 이미지를 지정해주세요."),
     minnie_POSTS_EMPTY_POST_INFO(false, HttpStatus.BAD_REQUEST.value(), "postInfo가 포함되어야 합니다."),
+    minnie_POST_SAVE_FAIL(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "게시물 저장에 실패했습니다."),
     minnie_POSTLOVES_NON_EXISTS_LOVE(false, HttpStatus.NOT_FOUND.value(), "좋아요가 존재하지 않습니다."),
 
     POSTLOVE_ALREADY_EXISTS(false, HttpStatus.BAD_REQUEST.value(), "이미 좋아요를 누른 게시물입니다."),

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
@@ -3,6 +3,8 @@ package com.spring.familymoments.domain.family;
 import com.spring.familymoments.domain.family.entity.Family;
 import com.spring.familymoments.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,4 +16,9 @@ public interface FamilyRepository extends JpaRepository<Family, Long> {
 
     //회원 탈퇴 시, 가족 생성자 권한 여부를 확인하기 위한 조회
     List<Family> findByOwner(User user);
+
+    @Query("SELECT CASE WHEN COUNT(uf) = 0 THEN false ELSE true END " +
+            "FROM UserFamily uf " +
+            "WHERE (uf.familyId = :family) AND (uf.userId = :user)")
+    Boolean isFamilyMember(@Param("family") Family family, @Param("user") User user);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -43,7 +43,6 @@ public class PostController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
     public BaseResponse<SinglePostRes> createPost(@AuthenticationPrincipal @Parameter(hidden = true) User user,
-                                                  @RequestHeader("X-AUTH-TOKEN") String requestAccessToken,
                                                   @RequestParam("familyId") long familyId,
                                                   @RequestPart("postInfo") PostInfoReq postInfoReq,
                                                   @RequestPart("img1")MultipartFile img1,
@@ -93,7 +92,6 @@ public class PostController {
     @PostMapping(value = "/{postId}/edit", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
     public BaseResponse<SinglePostRes> editPost(@AuthenticationPrincipal @Parameter(hidden = true) User user,
-                                                @RequestHeader("X-AUTH-TOKEN") String requestAccessToken,
                                                 @PathVariable long postId,
                                                 @RequestPart(name = "postInfo", required = false) PostInfoReq postInfoReq,
                                                 @RequestPart(name = "img1", required = false)MultipartFile img1,
@@ -130,7 +128,7 @@ public class PostController {
     @ResponseBody
     @DeleteMapping("/{postId}")
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
-    public BaseResponse<SinglePostRes> editPost(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
+    public BaseResponse<SinglePostRes> editPost(@AuthenticationPrincipal @Parameter(hidden = true) User user, @PathVariable long postId) {
         try {
             postService.deletePost(user, postId);
             return new BaseResponse<>(SUCCESS);
@@ -147,7 +145,7 @@ public class PostController {
     @ResponseBody
     @GetMapping(params = {"familyId"})
     @Operation(summary = "게시글 10건 조회", description = "최근 10개의 게시글을 조회합니다.")
-    public BaseResponse<List<MultiPostRes>> getRecentPosts(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId) {
+    public BaseResponse<List<MultiPostRes>> getRecentPosts(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestParam("familyId") long familyId) {
         try {
             List<MultiPostRes> multiPostRes = postService.getPosts(user.getUserId(), familyId);
             return new BaseResponse<>(multiPostRes);
@@ -164,7 +162,7 @@ public class PostController {
     @ResponseBody
     @GetMapping(params = {"familyId", "postId"})
     @Operation(summary = "게시글 수정(with paging)", description = "커서 이전의 게시물 10건을 조회합니다.")
-    public BaseResponse<List<MultiPostRes>> getNextPosts(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId, @RequestParam("postId") long postId) {
+    public BaseResponse<List<MultiPostRes>> getNextPosts(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestParam("familyId") long familyId, @RequestParam("postId") long postId) {
         try {
             List<MultiPostRes> multiPostRes = postService.getPosts(user.getUserId(), familyId, postId);
             return new BaseResponse<>(multiPostRes);
@@ -181,7 +179,7 @@ public class PostController {
     @ResponseBody
     @GetMapping("/{postId}")
     @Operation(summary = "게시글 조회", description = "게시글 1건을 조회합니다.")
-    public BaseResponse<SinglePostRes> getPost(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
+    public BaseResponse<SinglePostRes> getPost(@AuthenticationPrincipal @Parameter(hidden = true) User user, @PathVariable long postId) {
         try {
             SinglePostRes singlePostRes = postService.getPost(user.getUserId(), postId);
 
@@ -200,7 +198,6 @@ public class PostController {
     @GetMapping(value = "/calendar", params = {"familyId", "year", "month", "day"})
     @Operation(summary = "특정 일자 게시글 10건 조회", description = "특정 일자에 작성된 게시글을 최근 순으로 10건 조회합니다.")
     public  BaseResponse<List<MultiPostRes>> getPostsWithDate(@AuthenticationPrincipal @Parameter(hidden = true) User user,
-                                                              @RequestHeader("X-AUTH-TOKEN") String requestAccessToken,
                                                               @RequestParam("familyId") long familyId,
                                                               @RequestParam("year") int year,
                                                               @RequestParam("month") int month,
@@ -222,7 +219,6 @@ public class PostController {
     @GetMapping(value = "/calendar", params = {"familyId", "year", "month", "day", "postId"})
     @Operation(summary = "특정 일자 게시글 10건 조회(with paging)", description = "특정 일자의 커서 이후 게시글을 10건 조회합니다.")
     public  BaseResponse<List<MultiPostRes>> getPostsWithDate(@AuthenticationPrincipal @Parameter(hidden = true) User user,
-                                                              @RequestHeader("X-AUTH-TOKEN") String requestAccessToken,
                                                               @RequestParam("familyId") long familyId,
                                                               @RequestParam("year") int year,
                                                               @RequestParam("month") int month,
@@ -243,7 +239,7 @@ public class PostController {
      */
    @GetMapping(value = "/calendar", params = {"familyId", "year", "month"})
    @Operation(summary = "작성일자 리스트 조회", description = "해당 월 중 게시물이 작성된 날짜 리스트를 조회합니다.")
-   public BaseResponse<List<LocalDate>> getDatesExistPost(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId, @RequestParam("year") int year, @RequestParam("month") int month) {
+   public BaseResponse<List<LocalDate>> getDatesExistPost(@RequestParam("familyId") long familyId, @RequestParam("year") int year, @RequestParam("month") int month) {
        if(month < 1 || month > 12 || year > LocalDate.now().getYear()) {
            return new BaseResponse<>(minnie_POSTS_INVALID_POST_ID);
        }
@@ -264,7 +260,7 @@ public class PostController {
      */
     @GetMapping(value = "/album")
     @Operation(summary = "앨범 30건 조회", description = "최근 30건의 게시물을 앨범 형태에 맞춰 조회합니다.")
-    public BaseResponse<List<AlbumRes>> getRecentAlbum(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId) {
+    public BaseResponse<List<AlbumRes>> getRecentAlbum(@RequestParam("familyId") long familyId) {
         try {
             List<AlbumRes> album = postService.getAlbum(familyId);
             return new BaseResponse<>(album);
@@ -280,7 +276,7 @@ public class PostController {
      */
     @GetMapping(value = "/album", params = {"familyId", "postId"})
     @Operation(summary = "앨범 30건 조회(with paging)", description = "커서 이전의 30건의 게시물을 앨범 형태에 맞춰 조회합니다.")
-    public BaseResponse<List<AlbumRes>> getRecentAlbum(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId, @RequestParam("postId") long postId) {
+    public BaseResponse<List<AlbumRes>> getRecentAlbum(@RequestParam("familyId") long familyId, @RequestParam("postId") long postId) {
         try {
             List<AlbumRes> album = postService.getAlbum(familyId, postId);
             return new BaseResponse<>(album);
@@ -296,7 +292,7 @@ public class PostController {
      */
     @GetMapping(value = "/album/{postId}")
     @Operation(summary = "앨범 상세 조회", description = "앨범의 상세 페이지를 조회합니다.")
-    public BaseResponse<List<String>> getAlbumImages(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
+    public BaseResponse<List<String>> getAlbumImages(@PathVariable long postId) {
         try {
             List<String> imgs = postService.getPostImages(postId);
             return new BaseResponse<>(imgs);
@@ -313,7 +309,7 @@ public class PostController {
      */
     @GetMapping("/{postId}/post-loves")
     @Operation(summary = "좋아요 명단 조회", description = "특정 게시물의 좋아요를 누른 사람의 명단을 조회합니다.")
-    public BaseResponse<List<CommentRes>> getLovedList(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
+    public BaseResponse<List<CommentRes>> getLovedList(@PathVariable long postId) {
         try {
             List<CommentRes> heartedList = postLoveService.getHeartList(postId);
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -7,8 +7,12 @@ import com.spring.familymoments.domain.postLove.PostLoveService;
 import com.spring.familymoments.domain.user.AuthService;
 import com.spring.familymoments.domain.user.entity.User;
 import com.spring.familymoments.domain.user.model.CommentRes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -23,6 +27,7 @@ import static com.spring.familymoments.config.BaseResponseStatus.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Post", description = "게시물 API Document")
 @RequestMapping("/posts")
 public class PostController {
     private final PostService postService;
@@ -35,8 +40,9 @@ public class PostController {
      * @return BaseResponse<SinglePostRes>
      */
     @ResponseBody
-    @PostMapping
-    public BaseResponse<SinglePostRes> createPost(@AuthenticationPrincipal User user,
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
+    public BaseResponse<SinglePostRes> createPost(@AuthenticationPrincipal @Parameter(hidden = true) User user,
                                                   @RequestHeader("X-AUTH-TOKEN") String requestAccessToken,
                                                   @RequestParam("familyId") long familyId,
                                                   @RequestPart("postInfo") PostInfoReq postInfoReq,
@@ -93,8 +99,9 @@ public class PostController {
      * @return BaseResponse<SinglePostRes>
      */
     @ResponseBody
-    @PostMapping("/{postId}/edit")
-    public BaseResponse<SinglePostRes> editPost(@AuthenticationPrincipal User user,
+    @PostMapping(value = "/{postId}/edit", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
+    public BaseResponse<SinglePostRes> editPost(@AuthenticationPrincipal @Parameter(hidden = true) User user,
                                                 @RequestHeader("X-AUTH-TOKEN") String requestAccessToken,
                                                 @PathVariable long postId,
                                                 @RequestPart(name = "postInfo", required = false) PostInfoReq postInfoReq,
@@ -138,7 +145,8 @@ public class PostController {
      */
     @ResponseBody
     @DeleteMapping("/{postId}")
-    public BaseResponse<SinglePostRes> editPost(@AuthenticationPrincipal User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
+    public BaseResponse<SinglePostRes> editPost(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
         if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
             return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
         }
@@ -161,7 +169,8 @@ public class PostController {
      */
     @ResponseBody
     @GetMapping(params = {"familyId"})
-    public BaseResponse<List<MultiPostRes>> getRecentPosts(@AuthenticationPrincipal User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId) {
+    @Operation(summary = "게시글 10건 조회", description = "최근 10개의 게시글을 조회합니다.")
+    public BaseResponse<List<MultiPostRes>> getRecentPosts(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId) {
         if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
             return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
         }
@@ -184,7 +193,8 @@ public class PostController {
      */
     @ResponseBody
     @GetMapping(params = {"familyId", "postId"})
-    public BaseResponse<List<MultiPostRes>> getNextPosts(@AuthenticationPrincipal User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId, @RequestParam("postId") long postId) {
+    @Operation(summary = "게시글 수정(with paging)", description = "커서 이전의 게시물 10건을 조회합니다.")
+    public BaseResponse<List<MultiPostRes>> getNextPosts(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId, @RequestParam("postId") long postId) {
         if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
             return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
         }
@@ -207,7 +217,8 @@ public class PostController {
      */
     @ResponseBody
     @GetMapping("/{postId}")
-    public BaseResponse<SinglePostRes> getPost(@AuthenticationPrincipal User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
+    @Operation(summary = "게시글 조회", description = "게시글 1건을 조회합니다.")
+    public BaseResponse<SinglePostRes> getPost(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
         if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
             return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
         }
@@ -231,7 +242,8 @@ public class PostController {
      */
     @ResponseBody
     @GetMapping(value = "/calendar", params = {"familyId", "year", "month", "day"})
-    public  BaseResponse<List<MultiPostRes>> getPostsWithDate(@AuthenticationPrincipal User user,
+    @Operation(summary = "특정 일자 게시글 10건 조회", description = "특정 일자에 작성된 게시글을 최근 순으로 10건 조회합니다.")
+    public  BaseResponse<List<MultiPostRes>> getPostsWithDate(@AuthenticationPrincipal @Parameter(hidden = true) User user,
                                                               @RequestHeader("X-AUTH-TOKEN") String requestAccessToken,
                                                               @RequestParam("familyId") long familyId,
                                                               @RequestParam("year") int year,
@@ -259,7 +271,8 @@ public class PostController {
      */
     @ResponseBody
     @GetMapping(value = "/calendar", params = {"familyId", "year", "month", "day", "postId"})
-    public  BaseResponse<List<MultiPostRes>> getPostsWithDate(@AuthenticationPrincipal User user,
+    @Operation(summary = "특정 일자 게시글 10건 조회(with paging)", description = "특정 일자의 커서 이후 게시글을 10건 조회합니다.")
+    public  BaseResponse<List<MultiPostRes>> getPostsWithDate(@AuthenticationPrincipal @Parameter(hidden = true) User user,
                                                               @RequestHeader("X-AUTH-TOKEN") String requestAccessToken,
                                                               @RequestParam("familyId") long familyId,
                                                               @RequestParam("year") int year,
@@ -287,6 +300,7 @@ public class PostController {
      * @return BaseResponse<List<MultiPostRes>>
      */
    @GetMapping(value = "/calendar", params = {"familyId", "year", "month"})
+   @Operation(summary = "작성일자 리스트 조회", description = "해당 월 중 게시물이 작성된 날짜 리스트를 조회합니다.")
    public BaseResponse<List<LocalDate>> getDatesExistPost(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId, @RequestParam("year") int year, @RequestParam("month") int month) {
        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
@@ -311,6 +325,7 @@ public class PostController {
      * @return BaseResponse<List<AlbumRes>>
      */
     @GetMapping(value = "/album")
+    @Operation(summary = "앨범 30건 조회", description = "최근 30건의 게시물을 앨범 형태에 맞춰 조회합니다.")
     public BaseResponse<List<AlbumRes>> getRecentAlbum(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId) {
         if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
             return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
@@ -330,6 +345,7 @@ public class PostController {
      * @return BaseResponse<List<AlbumRes>>
      */
     @GetMapping(value = "/album", params = {"familyId", "postId"})
+    @Operation(summary = "앨범 30건 조회(with paging)", description = "커서 이전의 30건의 게시물을 앨범 형태에 맞춰 조회합니다.")
     public BaseResponse<List<AlbumRes>> getRecentAlbum(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId, @RequestParam("postId") long postId) {
         if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
             return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
@@ -349,6 +365,7 @@ public class PostController {
      * @return BaseResponse<List<String>>
      */
     @GetMapping(value = "/album/{postId}")
+    @Operation(summary = "앨범 상세 조회", description = "앨범의 상세 페이지를 조회합니다.")
     public BaseResponse<List<String>> getAlbumImages(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
         if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
             return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
@@ -369,6 +386,7 @@ public class PostController {
      * @return BaseResponse<List<CommentRes>>
      */
     @GetMapping("/{postId}/post-loves")
+    @Operation(summary = "좋아요 명단 조회", description = "특정 게시물의 좋아요를 누른 사람의 명단을 조회합니다.")
     public BaseResponse<List<CommentRes>> getLovedList(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
         if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
             return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -50,13 +50,6 @@ public class PostController {
                                                   @RequestPart(name = "img2", required = false)MultipartFile img2,
                                                   @RequestPart(name = "img3", required = false)MultipartFile img3,
                                                   @RequestPart(name = "img4", required = false)MultipartFile img4){
-        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
-        }
-        if(user == null) {
-            return new BaseResponse<>(INVALID_USER_JWT); //403 error : 유효한 사용자가 아님.
-        }
-
         if(postInfoReq == null) {
             return new BaseResponse<>(minnie_POSTS_EMPTY_POST_INFO);
         }
@@ -74,8 +67,6 @@ public class PostController {
         if(imgs.isEmpty()) {
             return new BaseResponse<>(minnie_POSTS_EMPTY_IMAGE);
         }
-
-        System.out.println(user.getUserId());
 
         PostReq postReq = PostReq.builder()
                 .familyId(familyId)
@@ -109,13 +100,6 @@ public class PostController {
                                                 @RequestPart(name = "img2", required = false)MultipartFile img2,
                                                 @RequestPart(name = "img3", required = false)MultipartFile img3,
                                                 @RequestPart(name = "img4", required = false)MultipartFile img4) {
-        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
-        }
-        if(user == null) {
-            return new BaseResponse<>(INVALID_USER_JWT); //403 error : 유효한 사용자가 아님.
-        }
-
         if(postInfoReq == null && img1 == null && img2 == null && img3 == null && img4 == null) {
             return new BaseResponse<>(minnie_POSTS_EMPTY_UPDATE);
         }
@@ -147,13 +131,6 @@ public class PostController {
     @DeleteMapping("/{postId}")
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
     public BaseResponse<SinglePostRes> editPost(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
-        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
-        }
-        if(user == null) {
-            return new BaseResponse<>(INVALID_USER_JWT); //403 error : 유효한 사용자가 아님.
-        }
-
         try {
             postService.deletePost(user, postId);
             return new BaseResponse<>(SUCCESS);
@@ -171,13 +148,6 @@ public class PostController {
     @GetMapping(params = {"familyId"})
     @Operation(summary = "게시글 10건 조회", description = "최근 10개의 게시글을 조회합니다.")
     public BaseResponse<List<MultiPostRes>> getRecentPosts(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId) {
-        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
-        }
-        if(user == null) {
-            return new BaseResponse<>(INVALID_USER_JWT); //403 error : 유효한 사용자가 아님.
-        }
-
         try {
             List<MultiPostRes> multiPostRes = postService.getPosts(user.getUserId(), familyId);
             return new BaseResponse<>(multiPostRes);
@@ -195,13 +165,6 @@ public class PostController {
     @GetMapping(params = {"familyId", "postId"})
     @Operation(summary = "게시글 수정(with paging)", description = "커서 이전의 게시물 10건을 조회합니다.")
     public BaseResponse<List<MultiPostRes>> getNextPosts(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId, @RequestParam("postId") long postId) {
-        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
-        }
-        if(user == null) {
-            return new BaseResponse<>(INVALID_USER_JWT); //403 error : 유효한 사용자가 아님.
-        }
-
         try {
             List<MultiPostRes> multiPostRes = postService.getPosts(user.getUserId(), familyId, postId);
             return new BaseResponse<>(multiPostRes);
@@ -219,13 +182,6 @@ public class PostController {
     @GetMapping("/{postId}")
     @Operation(summary = "게시글 조회", description = "게시글 1건을 조회합니다.")
     public BaseResponse<SinglePostRes> getPost(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
-        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
-        }
-        if(user == null) {
-            return new BaseResponse<>(INVALID_USER_JWT); //403 error : 유효한 사용자가 아님.
-        }
-
         try {
             SinglePostRes singlePostRes = postService.getPost(user.getUserId(), postId);
 
@@ -249,13 +205,6 @@ public class PostController {
                                                               @RequestParam("year") int year,
                                                               @RequestParam("month") int month,
                                                               @RequestParam("day") int day) {
-        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
-        }
-        if(user == null) {
-            return new BaseResponse<>(INVALID_USER_JWT); //403 error : 유효한 사용자가 아님.
-        }
-
         try {
             List<MultiPostRes> multiPostRes = postService.getPostsOfDate(user.getUserId(), familyId, year, month, day);
             return new BaseResponse<>(multiPostRes);
@@ -279,13 +228,6 @@ public class PostController {
                                                               @RequestParam("month") int month,
                                                               @RequestParam("day") int day,
                                                               @RequestParam("postId") long postId) {
-        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
-        }
-        if(user == null) {
-            return new BaseResponse<>(INVALID_USER_JWT); //403 error : 유효한 사용자가 아님.
-        }
-
         try {
             List<MultiPostRes> multiPostRes = postService.getPostsOfDate(user.getUserId(), familyId, year, month, day, postId);
             return new BaseResponse<>(multiPostRes);
@@ -302,10 +244,6 @@ public class PostController {
    @GetMapping(value = "/calendar", params = {"familyId", "year", "month"})
    @Operation(summary = "작성일자 리스트 조회", description = "해당 월 중 게시물이 작성된 날짜 리스트를 조회합니다.")
    public BaseResponse<List<LocalDate>> getDatesExistPost(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId, @RequestParam("year") int year, @RequestParam("month") int month) {
-       if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-           return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
-       }
-
        if(month < 1 || month > 12 || year > LocalDate.now().getYear()) {
            return new BaseResponse<>(minnie_POSTS_INVALID_POST_ID);
        }
@@ -327,10 +265,6 @@ public class PostController {
     @GetMapping(value = "/album")
     @Operation(summary = "앨범 30건 조회", description = "최근 30건의 게시물을 앨범 형태에 맞춰 조회합니다.")
     public BaseResponse<List<AlbumRes>> getRecentAlbum(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId) {
-        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
-        }
-
         try {
             List<AlbumRes> album = postService.getAlbum(familyId);
             return new BaseResponse<>(album);
@@ -347,10 +281,6 @@ public class PostController {
     @GetMapping(value = "/album", params = {"familyId", "postId"})
     @Operation(summary = "앨범 30건 조회(with paging)", description = "커서 이전의 30건의 게시물을 앨범 형태에 맞춰 조회합니다.")
     public BaseResponse<List<AlbumRes>> getRecentAlbum(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @RequestParam("familyId") long familyId, @RequestParam("postId") long postId) {
-        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
-        }
-
         try {
             List<AlbumRes> album = postService.getAlbum(familyId, postId);
             return new BaseResponse<>(album);
@@ -367,10 +297,6 @@ public class PostController {
     @GetMapping(value = "/album/{postId}")
     @Operation(summary = "앨범 상세 조회", description = "앨범의 상세 페이지를 조회합니다.")
     public BaseResponse<List<String>> getAlbumImages(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
-        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
-        }
-
         try {
             List<String> imgs = postService.getPostImages(postId);
             return new BaseResponse<>(imgs);
@@ -388,10 +314,6 @@ public class PostController {
     @GetMapping("/{postId}/post-loves")
     @Operation(summary = "좋아요 명단 조회", description = "특정 게시물의 좋아요를 누른 사람의 명단을 조회합니다.")
     public BaseResponse<List<CommentRes>> getLovedList(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken, @PathVariable long postId) {
-        if (authService.validate(requestAccessToken)) { //유효한 사용자라 true가 반환됩니다 !!
-            return new BaseResponse<>(INVALID_JWT); //401 error : 유효한 사용자이지만, 토큰의 유효 기간이 만료됨.
-        }
-
         try {
             List<CommentRes> heartedList = postLoveService.getHeartList(postId);
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -124,13 +124,11 @@ public class PostService {
         }
 
         for(int i = 0 ; i < 4; i++) {
-            String url;
+            String url = null;
 
             if(postReq.getImgs().size() > i && postReq.getImgs().get(i) != null) {
                 MultipartFile img = postReq.getImgs().get(i);
                 url = awsS3Service.uploadImage(img);
-            } else {
-                url = null;
             }
 
             if(url != null) {

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -38,6 +38,9 @@ public class PostService {
     private final AwsS3Service awsS3Service;
     private final FamilyRepository familyRepository;
 
+    private static final int POST_PAGES = 10;
+    private static final int ALBUM_PAGES = 30;
+
     @Transactional
     public SinglePostRes createPosts(User user, PostReq postReq) {
         // familyID 유효성 검사
@@ -175,7 +178,7 @@ public class PostService {
 
     // 현재 가족의 모든 게시물 중 최근 10개를 조회
     public List<MultiPostRes> getPosts(long userId, long familyId) {
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(0, POST_PAGES);
         List<MultiPostRes> multiPostReses = postRepository.findByFamilyId(familyId, userId, pageable);
 
         if(multiPostReses.isEmpty()) {
@@ -187,7 +190,7 @@ public class PostService {
 
     // 현재 가족의 모든 게시물 중 특정 postId 보다 작은 10개를 조회
     public List<MultiPostRes> getPosts(long userId, long familyId, long postId) {
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(0, POST_PAGES);
         List<MultiPostRes> multiPostReses = postRepository.findByFamilyId(familyId, userId, postId, pageable);
 
         if(multiPostReses.isEmpty()) {
@@ -221,7 +224,7 @@ public class PostService {
 
         LocalDateTime dateTime = LocalDateTime.of(date, dummy);
 
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(0, POST_PAGES);
         List<MultiPostRes> posts = postRepository.findByFamilyIdWithDate(familyId, userId, dateTime, pageable);
 
         if(posts.isEmpty()) {
@@ -239,7 +242,7 @@ public class PostService {
 
         LocalDateTime dateTime = LocalDateTime.of(date, dummy);
 
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(0, POST_PAGES);
         List<MultiPostRes> posts = postRepository.findByFamilyIdWithDateAfterPostId(familyId, userId, dateTime, postId, pageable);
 
         if(posts.isEmpty()) {
@@ -275,7 +278,7 @@ public class PostService {
 
     @Transactional
     public List<AlbumRes> getAlbum (long familyId) {
-        Pageable pageable = PageRequest.of(0, 30);
+        Pageable pageable = PageRequest.of(0, ALBUM_PAGES);
         List<Post> posts = postRepository.findByFamilyIdAndStatusOrderByPostIdDesc(new Family(familyId), BaseEntity.Status.ACTIVE, pageable);
 
         if(posts.isEmpty()) {
@@ -293,7 +296,7 @@ public class PostService {
 
     @Transactional
     public List<AlbumRes> getAlbum (long familyId, long postId) {
-        Pageable pageable = PageRequest.of(0, 30);
+        Pageable pageable = PageRequest.of(0, ALBUM_PAGES);
         List<Post> posts = postRepository.findByFamilyIdAndPostIdLessThanAndStatusOrderByPostIdDesc(new Family(familyId), postId, BaseEntity.Status.ACTIVE, pageable);
 
         if(posts.isEmpty()) {

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -44,6 +44,11 @@ public class PostService {
         Family family = familyRepository.findById(postReq.getFamilyId())
                 .orElseThrow(() -> new BaseException(FIND_FAIL_FAMILY));
 
+        // 가족의 구성원이 아닌 경우, val
+        if(!familyRepository.isFamilyMember(family, user))
+            throw new BaseException(minnie_FAMILY_INVALID_USER);
+
+
         // image 업로드
         List<String> urls = awsS3Service.uploadImages(postReq.getImgs());
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -96,7 +96,7 @@ public class PostService {
 
     // post update
     @Transactional
-    public SinglePostRes editPost(User user, long postId, PostReq postReq) throws BaseException {
+    public SinglePostRes editPost(User user, long postId, PostReq postReq) {
         Post editedPost = postRepository.findById(postId).orElseThrow(() -> new BaseException(minnie_POSTS_NON_EXISTS_POST));
 
         if(editedPost.getStatus() == BaseEntity.Status.INACTIVE) {
@@ -154,7 +154,7 @@ public class PostService {
 
     // post delete
     @Transactional
-    public void deletePost(User user, long postId) throws BaseException {
+    public void deletePost(User user, long postId) {
         Post deletedPost = postRepository.findById(postId).orElseThrow(() -> new BaseException(minnie_POSTS_NON_EXISTS_POST));
 
         if(deletedPost.getStatus() == BaseEntity.Status.INACTIVE) {
@@ -169,7 +169,7 @@ public class PostService {
     }
 
     // 현재 가족의 모든 게시물 중 최근 10개를 조회
-    public List<MultiPostRes> getPosts(long userId, long familyId) throws BaseException {
+    public List<MultiPostRes> getPosts(long userId, long familyId) {
         Pageable pageable = PageRequest.of(0, 10);
         List<MultiPostRes> multiPostReses = postRepository.findByFamilyId(familyId, userId, pageable);
 
@@ -181,7 +181,7 @@ public class PostService {
     }
 
     // 현재 가족의 모든 게시물 중 특정 postId 보다 작은 10개를 조회
-    public List<MultiPostRes> getPosts(long userId, long familyId, long postId) throws BaseException {
+    public List<MultiPostRes> getPosts(long userId, long familyId, long postId) {
         Pageable pageable = PageRequest.of(0, 10);
         List<MultiPostRes> multiPostReses = postRepository.findByFamilyId(familyId, userId, postId, pageable);
 
@@ -194,7 +194,7 @@ public class PostService {
 
     // 특정 post 조회
     @Transactional
-    public SinglePostRes getPost(long userId, long postId) throws BaseException {
+    public SinglePostRes getPost(long userId, long postId) {
         // countLove 칼럼 갱신
         postRepository.updateCountLove(postId);
 
@@ -210,7 +210,7 @@ public class PostService {
 
     // 특정 일 최신 post 조회
     @Transactional
-    public List<MultiPostRes> getPostsOfDate(long userId, long familyId, int year, int month, int day) throws BaseException{
+    public List<MultiPostRes> getPostsOfDate(long userId, long familyId, int year, int month, int day) {
         LocalDate date = LocalDate.of(year, month, day);
         LocalTime dummy = LocalTime.MIDNIGHT; // LocalDateTime 변수 생성을 위한 dummy 값
 
@@ -228,7 +228,7 @@ public class PostService {
 
     // 특정 일 postId 이후 post 조회
     @Transactional
-    public List<MultiPostRes> getPostsOfDate(long userId, long familyId, int year, int month, int day, long postId) throws BaseException{
+    public List<MultiPostRes> getPostsOfDate(long userId, long familyId, int year, int month, int day, long postId) {
         LocalDate date = LocalDate.of(year, month, day);
         LocalTime dummy = LocalTime.MIDNIGHT; // LocalDateTime 변수 생성을 위한 dummy 값
 
@@ -245,7 +245,7 @@ public class PostService {
     }
 
     @Transactional
-    public List<LocalDate> getDayExistsPost(long familyId, int year, int month) throws BaseException {
+    public List<LocalDate> getDayExistsPost(long familyId, int year, int month) {
         // date 정보 생성
         YearMonth month_info = YearMonth.of(year, month);
         LocalDate start_date = month_info.atDay(1);
@@ -269,7 +269,7 @@ public class PostService {
     }
 
     @Transactional
-    public List<AlbumRes> getAlbum (long familyId) throws BaseException {
+    public List<AlbumRes> getAlbum (long familyId) {
         Pageable pageable = PageRequest.of(0, 30);
         List<Post> posts = postRepository.findByFamilyIdAndStatusOrderByPostIdDesc(new Family(familyId), BaseEntity.Status.ACTIVE, pageable);
 
@@ -287,7 +287,7 @@ public class PostService {
     }
 
     @Transactional
-    public List<AlbumRes> getAlbum (long familyId, long postId) throws BaseException {
+    public List<AlbumRes> getAlbum (long familyId, long postId) {
         Pageable pageable = PageRequest.of(0, 30);
         List<Post> posts = postRepository.findByFamilyIdAndPostIdLessThanAndStatusOrderByPostIdDesc(new Family(familyId), postId, BaseEntity.Status.ACTIVE, pageable);
 
@@ -305,7 +305,7 @@ public class PostService {
     }
 
     @Transactional
-    public List<String> getPostImages(long postId) throws BaseException {
+    public List<String> getPostImages(long postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new BaseException(minnie_POSTS_INVALID_POST_ID));
 
         List<String> imgs = post.getImgs();

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/model/AlbumRes.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/model/AlbumRes.java
@@ -1,5 +1,6 @@
 package com.spring.familymoments.domain.post.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,7 +10,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Schema(description = "Album Response")
 public class AlbumRes {
+    @Schema(description = "post ID", example = "12312")
     private long postId;
+    @Schema(description = "Post main img", example = "https://url.com/name.png")
     private String img1;
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/model/MultiPostRes.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/model/MultiPostRes.java
@@ -3,6 +3,7 @@ package com.spring.familymoments.domain.post.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.spring.familymoments.domain.common.BaseEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -17,15 +18,23 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor(force = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Multi-post Response(without number of loved)")
 public class MultiPostRes {
+    @Schema(description = "postId", example = "12343")
     private Long postId;
+    @Schema(description = "작성자", example = "민니")
     private String writer;
+    @Schema(description = "작성자 프로필 이미지", example = "https://url.com/name.png")
     private String profileImg;
+    @Schema(description = "게시글 본문", example = "좋은 하루~")
     private String content;
+    @Schema(description = "게시글 내 사진 리스트", example = "[https://url.com/img.png, https://url.com/img1.png]")
     private List<String> imgs;
     @JsonIgnore
     private LocalDateTime createdAtLocalDateTime;
+    @Schema(description = "게시글 생성일", example = "yyyy-MM-dd")
     private LocalDate createdAt;
+    @Schema(description = "나의 좋아요 여부", example = "true or false")
     private Boolean loved;
 
     public MultiPostRes(Long postId, String writer, String profileImg, String content, String imgs, LocalDateTime createdAt, BaseEntity.Status status) {

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/model/PostInfoReq.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/model/PostInfoReq.java
@@ -1,11 +1,14 @@
 package com.spring.familymoments.domain.post.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Setter
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "게시물 생성 및 수정 Request")
 public class PostInfoReq {
+    @Schema(description = "게시물 본문", example = "오늘은 날씨가 좋아요")
     String content;
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/model/SinglePostRes.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/model/SinglePostRes.java
@@ -2,6 +2,7 @@ package com.spring.familymoments.domain.post.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -16,16 +17,25 @@ import java.util.List;
 @NoArgsConstructor(force = true)
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Single post Response (with number of loved)")
 public class SinglePostRes {
+    @Schema(description = "postId", example = "12343")
     private Long postId;
+    @Schema(description = "작성자", example = "민니")
     private String writer;
+    @Schema(description = "작성자 프로필 이미지", example = "https://url.com/name.png")
     private String profileImg;
+    @Schema(description = "게시글 본문", example = "좋은 하루~")
     private String content;
+    @Schema(description = "게시글 내 사진 리스트", example = "[https://url.com/img.png, https://url.com/img1.png]")
     private List<String> imgs;
     @JsonIgnore
     private LocalDateTime createdAtLocalDateTime;
+    @Schema(description = "게시글 생성일", example = "yyyy-MM-dd")
     private LocalDate createdAt;
+    @Schema(description = "게시글의 좋아요 개수", example = "2")
     private int countLove;
+    @Schema(description = "나의 좋아요 여부", example = "true or false")
     private Boolean loved;
 
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : Swagger 도입에 따른 post domain의 swagger 세팅
- [ ] 버그 수정 :
- [x] 리펙토링 : Error Handling refactoring
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- Swagger document 세팅
  - `Controller`, `DTO` 설명 및 예시 작성
  - Validation Check를 위해 사용하는 `User`가 docs에 노출되는 문제의 경우, 
  @Parameter(hidden = true) annotation을 사용해 숨김 처리
  ![image](https://github.com/familymoments/family-moments-BE/assets/90233522/e95add8b-fa48-4b60-8fac-92ae2f2511d1)
- Error refactoring
  - AuthIncepter 도입에 따른 Controller단의 중복 val 과정 삭제
  - Service단의 `throw BaseException` 구문 삭제
  - createPost 시 error case 추가
    - 유저가 해당 가족의 멤버인지를 확인하는 validation 구문 추가
    - post 생성에 실패한 경우 error 추가

 
