### PR TITLE
Fix: 회원 가입 API 수정

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailController.java
@@ -38,11 +38,11 @@ public class EmailController {
             throws BaseException, MessagingException, UnsupportedEncodingException {
 
         //이름
-        if(sendEmailReq.getName() == null || sendEmailReq.getName().isEmpty()) {
+        if(sendEmailReq.getName().isEmpty()) {
             return new BaseResponse<>(POST_USERS_EMPTY_NAME);
         }
         //이메일
-        if(sendEmailReq.getEmail() == null || sendEmailReq.getEmail().isEmpty()) {
+        if(sendEmailReq.getEmail().isEmpty()) {
             return new BaseResponse<>(POST_USERS_EMPTY_EMAIL);
         }
         if(!isRegexEmail(sendEmailReq.getEmail())) {

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -74,14 +74,11 @@ public class UserController {
             return new BaseResponse<>(POST_USERS_EXISTS_ID);
         }
         //비밀번호
-        if (postUserReq.getPasswordA().isEmpty() || postUserReq.getPasswordB().isEmpty()) {
+        if (postUserReq.getPassword().isEmpty()) {
             return new BaseResponse<>(EMPTY_PASSWORD);
         }
-        if (!isRegexPw(postUserReq.getPasswordA()) || !isRegexPw(postUserReq.getPasswordB())) {
+        if (!isRegexPw(postUserReq.getPassword())) {
             return new BaseResponse<>(POST_USERS_INVALID_PW);
-        }
-        if(!postUserReq.getPasswordA().equals(postUserReq.getPasswordB())) {
-            return new BaseResponse<>(NOT_EQUAL_NEW_PASSWORD);
         }
         //이름
         if (postUserReq.getName().isEmpty()) {
@@ -181,11 +178,11 @@ public class UserController {
             throws MessagingException {
 
         //이름
-        if(sendEmailReq.getName() == null || sendEmailReq.getName().isEmpty()) {
+        if(sendEmailReq.getName().isEmpty()) {
             return new BaseResponse<>(POST_USERS_EMPTY_NAME);
         }
         //이메일
-        if(sendEmailReq.getEmail() == null || sendEmailReq.getEmail().isEmpty()) {
+        if(sendEmailReq.getEmail().isEmpty()) {
             return new BaseResponse<>(POST_USERS_EMPTY_EMAIL);
         }
         if(!isRegexEmail(sendEmailReq.getEmail())) {
@@ -241,11 +238,11 @@ public class UserController {
             throws MessagingException {
 
         //이름
-        if(sendEmailReq.getName() == null || sendEmailReq.getName().isEmpty()) {
+        if(sendEmailReq.getName().isEmpty()) {
             return new BaseResponse<>(POST_USERS_EMPTY_NAME);
         }
         //이메일
-        if(sendEmailReq.getEmail() == null || sendEmailReq.getEmail().isEmpty()) {
+        if(sendEmailReq.getEmail().isEmpty()) {
             return new BaseResponse<>(POST_USERS_EMPTY_EMAIL);
         }
         if(!isRegexEmail(sendEmailReq.getEmail())) {
@@ -432,14 +429,11 @@ public class UserController {
 
         try {
             if(userService.checkDuplicateId(memberId)) {
+                if(patchPwdWithoutLoginReq.getPasswordA().isEmpty() || patchPwdWithoutLoginReq.getPasswordB().isEmpty()) {
+                    return new BaseResponse<>(EMPTY_PASSWORD);
+                }
                 if(!isRegexPw(patchPwdWithoutLoginReq.getPasswordA()) || !isRegexPw(patchPwdWithoutLoginReq.getPasswordB())) {
                     return new BaseResponse<>(POST_USERS_INVALID_PW);
-                }
-                if(patchPwdWithoutLoginReq.getPasswordA() == "" || patchPwdWithoutLoginReq.getPasswordA().isEmpty()) {
-                    return new BaseResponse<>(EMPTY_PASSWORD);
-                }
-                if(patchPwdWithoutLoginReq.getPasswordB() == "" || patchPwdWithoutLoginReq.getPasswordB().isEmpty()) {
-                    return new BaseResponse<>(EMPTY_PASSWORD);
                 }
                 if(!patchPwdWithoutLoginReq.getPasswordA().equals(patchPwdWithoutLoginReq.getPasswordB())) {
                     return new BaseResponse<>(NOT_EQUAL_NEW_PASSWORD);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -89,7 +89,7 @@ public class UserService {
                 .id(postUserReq.getId())
                 .uuid(uuid)
                 .email(postUserReq.getEmail())
-                .password(passwordEncoder.encode(postUserReq.getPasswordA()))
+                .password(passwordEncoder.encode(postUserReq.getPassword()))
                 .name(postUserReq.getName())
                 .nickname(postUserReq.getNickname())
                 .birthDate(parsedBirthDate)
@@ -204,7 +204,7 @@ public class UserService {
      * [GET] /users/invitation
      * @return List<GetInvitationRes>: 회원이 받은 초대 요청 리스트
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public List<GetInvitationRes> getInvitationList(User loginUser){
         List<GetInvitationRes> getInvitationResList = new ArrayList<>();
         List<UserFamily> userFamilyList = userFamilyRepository.findAllByUserIdOrderByCreatedAtDesc(loginUser);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostUserReq.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostUserReq.java
@@ -18,10 +18,7 @@ public class PostUserReq {
         private String id;
         @NotBlank(message = "비밀번호를 입력해주세요.")
         @Schema(description = "비밀번호", example = "family1212")
-        private String passwordA;
-        @NotBlank(message = "비밀번호를 한 번 더 입력해주세요.")
-        @Schema(description = "비밀번호 확인", example = "family1212")
-        private String passwordB;
+        private String password;
         @NotBlank(message = "이름을 입력해주세요.")
         @Schema(description = "이름", example = "김철수")
         private String name;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 회원 가입 API에서 비밀번호 입력 폼을 2개에서 1개로 수정
- [x] 리펙토링 : `isEmpty()` 적용, `readOnly = True` 옵션 적용(https://github.com/familymoments/family-moments-BE/pull/123)
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 회원 가입 API에서 비밀번호 입력 폼을 2개에서 1개로 수정

### 작업 내역

- 회원 가입 API에서 비밀번호 입력 폼을 2개에서 1개로 수정 

### 작업 후 기대 동작(스크린샷)

![image](https://github.com/familymoments/family-moments-BE/assets/55887179/3607559e-0d20-4d70-a74d-c403fede64d9)

### PR 특이 사항

- `isEmpty()`가 적용되지 않은 API들이 있어서 전부 수정했습니다.
- `throw`관련 코드 정리는 다음 PR에 적용하겠습니다!

### Issue Number 

close: #

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
