### PR TITLE
fix: 잘못된 폼 전달 시, 400 bad request 응답만 뜨고 return이 안되는 문제

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/advice/ExceptionAdvice.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/advice/ExceptionAdvice.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import javax.servlet.http.HttpServletRequest;
@@ -57,6 +58,16 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         BaseResponse<Object> baseResponse = new BaseResponse<>(false, errorMessage, HttpStatus.BAD_REQUEST.value());
 
         return handleExceptionInternal(ex, baseResponse,  new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
+    }
+
+    /** Required request part exception **/
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestPart(MissingServletRequestPartException ex, HttpHeaders headers,
+                                                                     HttpStatus status, WebRequest request) {
+        String errorMessage = ex.getMessage();
+        BaseResponse<Object> baseResponse = new BaseResponse<>(false, errorMessage, HttpStatus.BAD_REQUEST.value());
+
+        return handleExceptionInternal(ex, baseResponse, new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
     }
 
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : #124
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- spring MVC Exception의 경우, ExceptionAdvice가 ResponseEntityExceptionHandler을 상속받으면 reponse body가 빈 값으로 반환된다. request에 빠진 값이 있는 경우 MissingServletRequestPartException가 발생하는데 이 예외가 spring MVC 예외이기 때문에 빈 바디가 반환되었습니다.

### 작업 내역

- ExceptionAdvice에 MissingServletRequestPartException을 처리하는 함수를 override해주었습니다.
![image](https://github.com/familymoments/family-moments-BE/assets/68217805/0c176f2d-0f7d-4c9a-8906-63df6265640a)

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 더 찾아보고 추가할 예외가 있으면 추가하겠습니다!

close: #124 