### PR TITLE
소셜 로그인 및 회원가입 관련 기능 🟢 🟡 ⚪ 

### DIFF
--- a/family-moments/build.gradle
+++ b/family-moments/build.gradle
@@ -21,6 +21,16 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2021.0.8")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -60,6 +70,9 @@ dependencies {
 
 	// mongoDB
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+	// OpenFeign - social login
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {

--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -56,7 +56,7 @@ public enum BaseResponseStatus {
     FAILED_USERSS_UNATHORIZED(false, HttpStatus.BAD_REQUEST.value(), "권한이 없는 사용자입니다."),
     FIND_FAIL_POST(false, HttpStatus.BAD_REQUEST.value(), "비활성화된 게시글입니다."),
     NOT_EQUAL_NEW_PASSWORD(false, HttpStatus.BAD_REQUEST.value(), "입력한 비밀번호와 일치하지 않습니다."),
-
+    EXPIRED_AT_ERROR(false, 471, "탈퇴를 위해 가입했던 소셜 계정으로 재로그인 하세요"),
     /**
      * 500 : Database, Server 오류
      */

--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -23,7 +23,7 @@ public enum BaseResponseStatus {
     EMPTY_JWT(false, HttpStatus.UNAUTHORIZED.value(), "JWT를 입력해주세요."),
     INVALID_JWT(false, 461, "Access Token의 기한이 만료되었습니다. 재발급 API를 호출해주세요"),
     INVALID_USER_JWT(false,HttpStatus.FORBIDDEN.value(),"권한이 없는 유저의 접근입니다."),
-    RESPONSE_ERROR(false, HttpStatus.NOT_FOUND.value(), "값을 불러오는데 실패하였습니다."),
+    TOKEN_RESPONSE_ERROR(false, HttpStatus.NOT_FOUND.value(), "값을 불러오는데 실패하였습니다."),
     EXPIRED_JWT(false, HttpStatus.UNAUTHORIZED.value(), "만료된 토큰입니다."),
 
     // users
@@ -49,6 +49,7 @@ public enum BaseResponseStatus {
     FAILED_TO_LOGIN(false,HttpStatus.NOT_FOUND.value(), "탈퇴하거나 신고당한 유저입니다."),
     FIND_FAIL_FAMILY(false, HttpStatus.NOT_FOUND.value(), "존재하지 않는 가족입니다."),
     FAILED_INVITE_USER_FAMILY(false, HttpStatus.CONFLICT.value(), "이미 가족에 가입된 회원입니다."),
+    FAILED_SOCIAL_JOIN(false, HttpStatus.CONFLICT.value(), "이미 해당 소셜 계정이 있는 회원입니다."),
     EMPTY_PASSWORD(false, HttpStatus.BAD_REQUEST.value(), "비밀번호를 입력해주세요."),
     FAILED_AUTHENTICATION(false, HttpStatus.FORBIDDEN.value(), "비밀번호가 올바르지 않습니다."),
     EQUAL_NEW_PASSWORD(false, HttpStatus.BAD_REQUEST.value(), "기존 비밀번호와 같습니다."),

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/GoogleLoginServiceImpl.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/GoogleLoginServiceImpl.java
@@ -2,10 +2,7 @@ package com.spring.familymoments.domain.socialInfo;
 
 import com.spring.familymoments.domain.socialInfo.feign.google.GoogleAuthApi;
 import com.spring.familymoments.domain.socialInfo.feign.google.GoogleUserApi;
-import com.spring.familymoments.domain.socialInfo.model.GoogleLoginResponse;
-import com.spring.familymoments.domain.socialInfo.model.GoogleRequestAccessTokenDto;
-import com.spring.familymoments.domain.socialInfo.model.SocialAuthResponse;
-import com.spring.familymoments.domain.socialInfo.model.SocialUserResponse;
+import com.spring.familymoments.domain.socialInfo.model.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -65,5 +62,11 @@ public class GoogleLoginServiceImpl implements SocialLoginService {
                 .picture(googleLoginResponse.getPicture())
                 .email(googleLoginResponse.getEmail())
                 .build();
+    }
+
+    public String unlink(GoogleDeleteDto googleDeleteDto) {
+        ResponseEntity<String> response = googleAuthApi.unlink(googleDeleteDto);
+        log.info("google unlink response {}", response);
+        return response.getBody();
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/GoogleLoginServiceImpl.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/GoogleLoginServiceImpl.java
@@ -1,0 +1,69 @@
+package com.spring.familymoments.domain.socialInfo;
+
+import com.spring.familymoments.domain.socialInfo.feign.google.GoogleAuthApi;
+import com.spring.familymoments.domain.socialInfo.feign.google.GoogleUserApi;
+import com.spring.familymoments.domain.socialInfo.model.GoogleLoginResponse;
+import com.spring.familymoments.domain.socialInfo.model.GoogleRequestAccessTokenDto;
+import com.spring.familymoments.domain.socialInfo.model.SocialAuthResponse;
+import com.spring.familymoments.domain.socialInfo.model.SocialUserResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Qualifier("googleLoginService")
+public class GoogleLoginServiceImpl implements SocialLoginService {
+    private final GoogleAuthApi googleAuthApi;
+    private final GoogleUserApi googleUserApi;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String googleAppKey;
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String googleAppSecret;
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String googleRedirectUri;
+    @Value("${spring.security.oauth2.client.registration.google.authorization-grant-type}")
+    private String googleGrantType;
+
+    @Override
+    public UserType getServiceName() {
+        return UserType.GOOGLE;
+    }
+
+    @Override
+    public SocialAuthResponse getAccessToken(String authorizationCode) {
+        ResponseEntity<SocialAuthResponse> response = googleAuthApi.getAccessToken(
+                GoogleRequestAccessTokenDto.builder()
+                        .code(authorizationCode)
+                        .client_id(googleAppKey)
+                        .clientSecret(googleAppSecret)
+                        .redirect_uri(googleRedirectUri)
+                        .grant_type(googleGrantType)
+                        .build()
+        );
+
+        log.info("google auth info {}", response.toString());
+
+        return response.getBody();
+    }
+
+    @Override
+    public SocialUserResponse getUserInfo(String accessToken) {
+        ResponseEntity<GoogleLoginResponse> response = googleUserApi.getUserInfo(accessToken);
+        log.info("google user response {}", response.toString());
+
+        GoogleLoginResponse googleLoginResponse = response.getBody();
+
+        return SocialUserResponse.builder()
+                .snsId(googleLoginResponse.getId())
+                .name(googleLoginResponse.getName())
+                .picture(googleLoginResponse.getPicture())
+                .email(googleLoginResponse.getEmail())
+                .build();
+    }
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/KakaoLoginServiceImpl.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/KakaoLoginServiceImpl.java
@@ -1,0 +1,79 @@
+package com.spring.familymoments.domain.socialInfo;
+
+import com.spring.familymoments.domain.socialInfo.feign.kakao.KakaoAuthApi;
+import com.spring.familymoments.domain.socialInfo.feign.kakao.KakaoUserApi;
+import com.spring.familymoments.domain.socialInfo.model.KaKaoLoginResponse;
+import com.spring.familymoments.domain.socialInfo.model.SocialAuthResponse;
+import com.spring.familymoments.domain.socialInfo.model.SocialUserResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Qualifier("kakaoLoginService")
+public class KakaoLoginServiceImpl implements SocialLoginService {
+    private final KakaoAuthApi kakaoAuthApi;
+    private final KakaoUserApi kakaoUserApi;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoAppKey;
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String kakaoAppSecret;
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+    @Value("${spring.security.oauth2.client.registration.kakao.authorization-grant-type}")
+    private String kakaoGrantType;
+
+    @Override
+    public UserType getServiceName() {
+        return UserType.KAKAO;
+    }
+    @Override
+    public SocialAuthResponse getAccessToken(String authorizationCode) {
+        ResponseEntity<SocialAuthResponse> response = kakaoAuthApi.getAccessToken(
+                kakaoAppKey,
+                kakaoAppSecret,
+                kakaoGrantType,
+                kakaoRedirectUri,
+                authorizationCode
+        );
+
+        log.info("kakao auth response {}", response.toString());
+
+        return response.getBody();
+    }
+
+    @Override
+    public SocialUserResponse getUserInfo(String accessToken) {
+        Map<String, String> headerMap = new HashMap<>();
+        headerMap.put("authorization", "Bearer " + accessToken);
+
+        ResponseEntity<KaKaoLoginResponse> response = kakaoUserApi.getUserInfo(headerMap);
+
+        log.info("kakao user response {}", response.toString());
+
+        KaKaoLoginResponse kaKaoLoginResponse = response.getBody();
+        KaKaoLoginResponse.KakaoLoginData kakaoLoginData = kaKaoLoginResponse.getKakao_account();
+        KaKaoLoginResponse.KakaoLoginData.KakaoProfile kakaoProfile = kakaoLoginData.getProfile();
+
+        return SocialUserResponse.builder()
+                .snsId(kaKaoLoginResponse.getId())
+                .name(kakaoLoginData.getName())
+                .email(kakaoLoginData.getEmail())
+                .birthyear(kakaoLoginData.getBirthyear())
+                .birthday(kakaoLoginData.getBirthday())
+                .nickname(kakaoProfile.getNickname())
+                .picture(kakaoProfile.getProfile_image_url())
+                .build();
+    }
+
+
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/KakaoLoginServiceImpl.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/KakaoLoginServiceImpl.java
@@ -2,6 +2,7 @@ package com.spring.familymoments.domain.socialInfo;
 
 import com.spring.familymoments.domain.socialInfo.feign.kakao.KakaoAuthApi;
 import com.spring.familymoments.domain.socialInfo.feign.kakao.KakaoUserApi;
+import com.spring.familymoments.domain.socialInfo.model.KaKaoDeleteDto;
 import com.spring.familymoments.domain.socialInfo.model.KaKaoLoginResponse;
 import com.spring.familymoments.domain.socialInfo.model.SocialAuthResponse;
 import com.spring.familymoments.domain.socialInfo.model.SocialUserResponse;
@@ -75,5 +76,16 @@ public class KakaoLoginServiceImpl implements SocialLoginService {
                 .build();
     }
 
+    public String unlink(String accessToken, Long target_id) {
+        ResponseEntity<String> response = kakaoUserApi.unlink(
+                accessToken,
+                KaKaoDeleteDto.builder()
+                        .target_id_type("user_id")
+                        .target_id(target_id)
+                        .build()
+        );
 
+        log.info("kakao unlink response {}", response.toString());
+        return response.getBody();
+    }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/LoginServiceImpl.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/LoginServiceImpl.java
@@ -1,0 +1,27 @@
+package com.spring.familymoments.domain.socialInfo;
+
+import com.spring.familymoments.domain.socialInfo.model.SocialAuthResponse;
+import com.spring.familymoments.domain.socialInfo.model.SocialUserResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@Component
+@Qualifier("defaultLoginService")
+public class LoginServiceImpl implements SocialLoginService {
+    @Override
+    public UserType getServiceName() {
+        return UserType.NORMAL;
+    }
+    @Override
+    public SocialAuthResponse getAccessToken(String authorizationCode) {
+        return null;
+    }
+    @Override
+    public SocialUserResponse getUserInfo(String accessToken) {
+        return null;
+    }
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/NaverLoginServiceImpl.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/NaverLoginServiceImpl.java
@@ -76,4 +76,16 @@ public class NaverLoginServiceImpl implements SocialLoginService {
                 .picture(naverUserInfo.getProfile_image())
                 .build();
     }
+
+    public String unlink(String accessToken) {
+        ResponseEntity<String> response = naverUserApi.unlink(
+                naverAppKey,
+                naverAppSecret,
+                accessToken,
+                naverGrantType
+        );
+
+        log.info("naver unlink response {}", response.toString());
+        return response.getBody();
+    }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/NaverLoginServiceImpl.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/NaverLoginServiceImpl.java
@@ -1,0 +1,79 @@
+package com.spring.familymoments.domain.socialInfo;
+
+import com.spring.familymoments.domain.socialInfo.feign.naver.NaverAuthApi;
+import com.spring.familymoments.domain.socialInfo.feign.naver.NaverUserApi;
+import com.spring.familymoments.domain.socialInfo.model.NaverLoginResponse;
+import com.spring.familymoments.domain.socialInfo.model.SocialAuthResponse;
+import com.spring.familymoments.domain.socialInfo.model.SocialUserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Qualifier("naverLoginService")
+public class NaverLoginServiceImpl implements SocialLoginService {
+    private final NaverAuthApi naverAuthApi;
+    private final NaverUserApi naverUserApi;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String naverAppKey;
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String naverAppSecret;
+
+    @Value("${spring.security.oauth2.client.registration.naver.redirect-uri}")
+    private String naverRedirectUri;
+
+    @Value("${spring.security.oauth2.client.registration.naver.authorization-grant-type}")
+    private String naverGrantType;
+
+    @Override
+    public UserType getServiceName() {
+        return UserType.NAVER;
+    }
+
+    @Override
+    public SocialAuthResponse getAccessToken(String authorizationCode) {
+        ResponseEntity<SocialAuthResponse> response = naverAuthApi.getAccessToken(
+                naverGrantType,
+                naverAppKey,
+                naverAppSecret,
+                authorizationCode,
+                "state"
+        );
+
+        log.info("naver auth response {}", response.toString());
+
+        return response.getBody();
+    }
+
+    public SocialUserResponse getUserInfo(String accessToken) {
+        Map<String, String> headerMap = new HashMap<>();
+        headerMap.put("authorization", "Bearer " + accessToken);
+
+        ResponseEntity<NaverLoginResponse> response = naverUserApi.getUserInfo(headerMap);
+
+        log.info("naver user response");
+        log.info(response.toString());
+
+        NaverLoginResponse naverLoginResponse = response.getBody();
+        NaverLoginResponse.Response naverUserInfo = naverLoginResponse.getResponse();
+
+        return SocialUserResponse.builder()
+                .snsId(naverUserInfo.getId())
+                .name(naverUserInfo.getName())
+                .email(naverUserInfo.getEmail())
+                .birthyear(naverUserInfo.getBirthyear())
+                .birthday(naverUserInfo.getBirthday())
+                .nickname(naverUserInfo.getNickname())
+                .picture(naverUserInfo.getProfile_image())
+                .build();
+    }
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialLoginService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialLoginService.java
@@ -1,0 +1,12 @@
+package com.spring.familymoments.domain.socialInfo;
+
+import com.spring.familymoments.domain.socialInfo.model.SocialAuthResponse;
+import com.spring.familymoments.domain.socialInfo.model.SocialUserResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface SocialLoginService {
+    UserType getServiceName();
+    SocialAuthResponse getAccessToken(String authorizationCode);
+    SocialUserResponse getUserInfo(String accessToken);
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserController.java
@@ -8,6 +8,13 @@ import com.spring.familymoments.domain.awsS3.AwsS3Service;
 import com.spring.familymoments.domain.socialInfo.model.*;
 import com.spring.familymoments.domain.user.UserService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpCookie;
@@ -25,6 +32,7 @@ import static com.spring.familymoments.utils.ValidationRegex.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "SocialInfo", description = "네이버,카카오,구글 API Document")
 public class SocialUserController {
     private final SocialUserService socialUserService;
     private final UserService userService;
@@ -33,6 +41,10 @@ public class SocialUserController {
 
     @NoAuthCheck
     @PostMapping("/users/oauth2/social/login")
+    @Operation(summary = "소셜 로그인 (아이콘 클릭 시)", description = "기존 회원 대상 : 헤더로 토큰이 반환됩니다. / 신규 회원 대상(아래 예시 해당) : 사용자로부터 허용된 리소스 서버 정보들이 반환됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SocialLoginOrJoinResponse.JoinResponse.class)))
+    })
     public ResponseEntity<?> doSocialLogin(@Valid @RequestBody SocialLoginRequest request) throws Exception {
         SocialLoginOrJoinResponse socialLoginOrJoinResponse = socialUserService.doSocialLogin(request);
 
@@ -57,8 +69,12 @@ public class SocialUserController {
     }
     @NoAuthCheck
     @PostMapping("/users/oauth2/social/join")
-    public ResponseEntity<?> createSocialUser(@RequestPart("userJoinReq") UserJoinRequest userJoinRequest,
-                                                           @RequestPart("profileImg") MultipartFile profileImage) {
+    @Operation(summary = "소셜 회원가입과 로그인 (폼 입력)", description = "신규 회원 대상 : 얻은 리소스 서버 정보들과 사용자의 입력으로 유저를 등록하고 로그인(헤더로 토큰 발급)합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK")
+    })
+    public ResponseEntity<?> createSocialUser(@Parameter(description = "신규 회원의 가입 정보") @RequestPart("userJoinReq") UserJoinRequest userJoinRequest,
+                                              @Parameter(description = "신규 회원의 프로필 첨부파일") @RequestPart("profileImg") MultipartFile profileImage) {
         //아이디
         if (userJoinRequest.getId().isEmpty()) {
             return ResponseEntity.status(400)

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserController.java
@@ -1,0 +1,124 @@
+package com.spring.familymoments.domain.socialInfo;
+
+import com.spring.familymoments.config.BaseResponse;
+import com.spring.familymoments.config.NoAuthCheck;
+import com.spring.familymoments.config.secret.jwt.JwtSecret;
+import com.spring.familymoments.config.secret.jwt.model.TokenDto;
+import com.spring.familymoments.domain.awsS3.AwsS3Service;
+import com.spring.familymoments.domain.socialInfo.model.*;
+import com.spring.familymoments.domain.user.UserService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.Valid;
+
+import static com.spring.familymoments.config.BaseResponseStatus.*;
+import static com.spring.familymoments.utils.ValidationRegex.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class SocialUserController {
+    private final SocialUserService socialUserService;
+    private final UserService userService;
+    private final AwsS3Service awsS3Service;
+    private final long COOKIE_EXPIRATION = JwtSecret.COOKIE_EXPIRATION_TIME;
+
+    @NoAuthCheck
+    @PostMapping("/users/oauth2/social/login")
+    public ResponseEntity<?> doSocialLogin(@Valid @RequestBody SocialLoginRequest request) throws Exception {
+        SocialLoginOrJoinResponse socialLoginOrJoinResponse = socialUserService.doSocialLogin(request);
+
+        TokenDto tokenDto = socialLoginOrJoinResponse.getLoginResponse().getTokenDto();
+
+        if(tokenDto != null) {
+            //RefreshToken 쿠키에 저장
+            HttpCookie httpCookie = ResponseCookie.from("refresh-token", tokenDto.getRefreshToken())
+                    .maxAge(COOKIE_EXPIRATION)
+                    .httpOnly(true)
+                    .secure(true)
+                    .build();
+
+            //로그인
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, httpCookie.toString())
+                    .header("X-AUTH-TOKEN", tokenDto.getAccessToken()).build();
+        }
+        //회원 가입 유도
+        return ResponseEntity.ok()
+                .body(socialLoginOrJoinResponse.getJoinResponse());
+    }
+    @NoAuthCheck
+    @PostMapping("/users/oauth2/social/join")
+    public ResponseEntity<?> createSocialUser(@RequestPart("userJoinReq") UserJoinRequest userJoinRequest,
+                                                           @RequestPart("profileImg") MultipartFile profileImage) {
+        //아이디
+        if (userJoinRequest.getId().isEmpty()) {
+            return ResponseEntity.status(400)
+                    .body(new BaseResponse<>(USERS_EMPTY_USER_ID));
+        }
+        if (!isRegexId(userJoinRequest.getId())) {
+            return ResponseEntity.status(400)
+                    .body(new BaseResponse<>(POST_USERS_INVALID_ID));
+        }
+        //아이디 중복 체크
+        if (userService.checkDuplicateId(userJoinRequest.getId())) {
+            return ResponseEntity.status(400)
+                    .body(new BaseResponse<>(POST_USERS_EXISTS_ID));
+        }
+        //이름
+        if (userJoinRequest.getName().isEmpty()) {
+            return ResponseEntity.status(400)
+                    .body(new BaseResponse<>(POST_USERS_EMPTY_NAME));
+        }
+        //생년월일
+        if (userJoinRequest.getStrBirthDate().isEmpty()) {
+            return ResponseEntity.status(400)
+                    .body(new BaseResponse<>(POST_USERS_EMPTY_BIRTH));
+        }
+        if (!isRegexBirth(userJoinRequest.getStrBirthDate())) {
+            return ResponseEntity.status(400)
+                    .body(new BaseResponse<>(POST_USERS_INVALID_BIRTH));
+        }
+        //닉네임
+        if (userJoinRequest.getNickname().isEmpty()) {
+            return ResponseEntity.status(400)
+                    .body(new BaseResponse<>(POST_USERS_EMPTY_NICKNAME));
+        }
+        if (!isRegexNickName(userJoinRequest.getNickname())) {
+            return ResponseEntity.status(400)
+                    .body(new BaseResponse<>(POST_USERS_INVALID_NICKNAME));
+        }
+        //프로필 사진
+        String fileUrl = null;
+        if (userJoinRequest.getProfileImg() == null) {
+            fileUrl = awsS3Service.uploadImage(profileImage);
+        }
+        userJoinRequest.setProfileImg(fileUrl);
+
+        TokenDto tokenDto = socialUserService.createSocialUser(userJoinRequest);
+
+        if(tokenDto != null) {
+            //RefreshToken 쿠키에 저장
+            HttpCookie httpCookie = ResponseCookie.from("refresh-token", tokenDto.getRefreshToken())
+                    .maxAge(COOKIE_EXPIRATION)
+                    .httpOnly(true)
+                    .secure(true)
+                    .build();
+
+            //로그인
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, httpCookie.toString())
+                    .header("X-AUTH-TOKEN", tokenDto.getAccessToken()).build();
+        }
+        return ResponseEntity.ok()
+                .body(new BaseResponse<>(TOKEN_RESPONSE_ERROR));
+    }
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserRepository.java
@@ -1,0 +1,14 @@
+package com.spring.familymoments.domain.socialInfo;
+
+import com.spring.familymoments.domain.socialInfo.entity.SocialInfo;
+import com.spring.familymoments.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SocialUserRepository extends JpaRepository<SocialInfo, Long> {
+    @Query("SELECT u FROM User u LEFT JOIN SocialInfo si ON u = si.user WHERE u.email = :email AND si.type = :userType")
+    User findUserByEmailAndUserType(@Param("email") String email, @Param("userType") UserType userType);
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserRepository.java
@@ -7,8 +7,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SocialUserRepository extends JpaRepository<SocialInfo, Long> {
     @Query("SELECT u FROM User u LEFT JOIN SocialInfo si ON u = si.user WHERE u.email = :email AND si.type = :userType")
     User findUserByEmailAndUserType(@Param("email") String email, @Param("userType") UserType userType);
+    List<SocialInfo> findSocialInfoByUser(User user);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserService.java
@@ -1,0 +1,205 @@
+package com.spring.familymoments.domain.socialInfo;
+
+import com.spring.familymoments.config.BaseException;
+import com.spring.familymoments.config.secret.jwt.model.TokenDto;
+import com.spring.familymoments.domain.socialInfo.entity.SocialInfo;
+import com.spring.familymoments.domain.socialInfo.model.*;
+import com.spring.familymoments.domain.user.AuthService;
+import com.spring.familymoments.domain.user.UserDetailsService;
+import com.spring.familymoments.domain.user.UserRepository;
+import com.spring.familymoments.domain.user.entity.User;
+import com.spring.familymoments.utils.UuidUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Random;
+
+import static com.spring.familymoments.config.BaseResponseStatus.*;
+import static com.spring.familymoments.domain.user.entity.User.Status.ACTIVE;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SocialUserService {
+    private final List<SocialLoginService> loginServices;
+    private final SocialUserRepository socialUserRepository;
+    private final UserRepository userRepository;
+    private final UserDetailsService userDetailsService;
+    private final AuthService authService;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final String SERVER = "Server";
+    private final PasswordEncoder passwordEncoder;
+    @Value("${spring.security.oauth2.client.info.password}")
+    private String password;
+
+    @Transactional
+    public SocialLoginOrJoinResponse doSocialLogin(SocialLoginRequest request) {
+        UserType type = UserType.valueOf(request.getUserType());
+
+        SocialLoginService loginService = getLoginService(type);
+        //1. 인가코드로 액세스 토큰 요청
+        SocialAuthResponse socialAuthResponse = loginService.getAccessToken(request.getCode());
+
+        //2. 토큰으로 소셜 API 호출 : 액세스 토큰으로 사용자 정보 가져오기
+        SocialUserResponse socialUserResponse = loginService.getUserInfo(socialAuthResponse.getAccess_token());
+        User user = socialUserRepository.findUserByEmailAndUserType(socialUserResponse.getEmail(), type);
+
+        //+ 로그인 시 - REDIS 에 Social AT, RT 저장
+        saveSocialToken(socialAuthResponse, request.getUserType(), socialUserResponse.getSnsId());
+
+        TokenDto tokenDto = null;
+        String strBirthDate = null;
+        if(user != null) {
+            //3. 자체 로그인 처리 (회원가입 필요없음)
+            tokenDto = setAuthenticationInSocial(user);
+        }
+        if(socialUserResponse.getBirthday() != null && socialUserResponse.getBirthyear() != null) {
+            if(type.equals(UserType.NAVER)) {
+                //naver birthdate : MM-dd
+                String str = socialUserResponse.getBirthday().replace("-", "");
+                StringBuilder sb = new StringBuilder();
+                sb.append(socialUserResponse.getBirthyear());
+                sb.append(str);
+                strBirthDate = sb.toString();
+            } else {
+                //kakao birthdate : MMdd
+                strBirthDate = socialUserResponse.getBirthyear() + socialUserResponse.getBirthday();
+            }
+        }
+
+        SocialLoginOrJoinResponse.LoginResponse loginResponse = SocialLoginOrJoinResponse.LoginResponse.builder()
+                .tokenDto(tokenDto)
+                .build();
+
+        SocialLoginOrJoinResponse.JoinResponse joinResponse = SocialLoginOrJoinResponse.JoinResponse.builder()
+                .snsId(socialUserResponse.getSnsId())
+                .name(socialUserResponse.getName())
+                .email(socialUserResponse.getEmail())
+                .strBirthDate(strBirthDate)
+                .nickname(socialUserResponse.getNickname())
+                .picture(socialUserResponse.getPicture())
+                .build();
+
+        return new SocialLoginOrJoinResponse(loginResponse, joinResponse);
+    }
+    private SocialLoginService getLoginService(UserType userType) {
+        for(SocialLoginService loginService : loginServices) {
+            if(userType.equals(loginService.getServiceName())) {
+                log.info("login service name: {}", loginService.getServiceName());
+                return loginService;
+            }
+        }
+        return new LoginServiceImpl();
+    }
+    @Transactional
+    public void saveSocialToken(SocialAuthResponse socialAuthResponse, String userType, String snsId) {
+        Long atTimeOut = Long.parseLong(socialAuthResponse.getExpires_in()) * 1000L;
+        log.info("atTimeOut {}", atTimeOut);
+
+        //AT REDIS에 저장
+        authService.saveSocialToken("AT("+userType+"):", snsId,
+                socialAuthResponse.getAccess_token(),
+                atTimeOut);
+
+        Long rtTimeOut = null;
+        if(userType.equals("KAKAO")) {
+            //KAKAO RT REDIS에 저장
+            rtTimeOut = Long.parseLong(socialAuthResponse.getRefresh_token_expires_in()) * 1000;
+        } else if(userType.equals("NAVER")) {
+            //NAVER RT REDIS에 저장 - 1년(고정)
+            rtTimeOut = 31557600000L;
+        } else {
+            //GOOGLE RT REDIS에 저장 - 7일(고정)
+            rtTimeOut = 86400000L;
+        }
+        log.info("rtTimeOut {}", rtTimeOut);
+
+        authService.saveSocialToken("RT("+userType+"):", snsId,
+                socialAuthResponse.getRefresh_token(),
+                rtTimeOut);
+    }
+    @Transactional
+    public TokenDto createSocialUser(UserJoinRequest userJoinRequest) {
+        String email = userJoinRequest.getEmail();
+        UserType type = UserType.valueOf(userJoinRequest.getUserType());
+
+        User existedU = socialUserRepository.findUserByEmailAndUserType(email, type);
+        if(existedU != null) {
+            throw new BaseException(FAILED_SOCIAL_JOIN);
+        }
+
+        Long userId = joinUser(userJoinRequest);
+        User user = userRepository.findUserByUserId(userId)
+                .orElseThrow(() -> new BaseException(FIND_FAIL_USER_ID));
+
+        return setAuthenticationInSocial(user);
+        /*
+        회원가입 내용 반환 시
+        String formatPattern = "yyyyMMdd";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(formatPattern);
+        String strBirthDate = user.getBirthDate().format(formatter);
+        return new UserJoinResponse(user.getId(), user.getName(), strBirthDate, user.getNickname(), user.getProfileImg());
+        */
+    }
+
+    @Transactional
+    public Long joinUser(UserJoinRequest userJoinRequest) {
+        UserType userType = UserType.valueOf(userJoinRequest.getUserType());
+
+        //uuid 생성
+        String uuid = UuidUtils.generateUUID();
+
+        //날짜 자료형 변환
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        LocalDateTime parsedBirthDate = null;
+        parsedBirthDate = LocalDate.parse(userJoinRequest.getStrBirthDate(), dateTimeFormatter).atStartOfDay();
+
+        //user entity + socialInfo entity
+        User user = userRepository.save(
+                User.builder()
+                        .id(userJoinRequest.getId())
+                        .email(userJoinRequest.getEmail())
+                        .password(passwordEncoder.encode(password))
+                        .uuid(uuid)
+                        .name(userJoinRequest.getName())
+                        .nickname(userJoinRequest.getNickname())
+                        .birthDate(parsedBirthDate)
+                        .profileImg(userJoinRequest.getProfileImg())
+                        .status(ACTIVE)
+                        .build()
+        );
+        SocialInfo socialInfo = socialUserRepository.save(
+                SocialInfo.builder()
+                        .type(userType)
+                        .user(user)
+                        .snsUserId(userJoinRequest.getSnsId())
+                        .build()
+        );
+
+        return socialInfo.getUser().getUserId();
+    }
+
+    @Transactional
+    public TokenDto setAuthenticationInSocial(User user) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(user.getUuid());
+        UsernamePasswordAuthenticationToken authenticationToken
+                = new UsernamePasswordAuthenticationToken(userDetails.getUsername(), password, userDetails.getAuthorities());
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return authService.generateToken(SERVER, authentication.getName());
+    }
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/UserType.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/UserType.java
@@ -1,0 +1,8 @@
+package com.spring.familymoments.domain.socialInfo;
+
+public enum UserType {
+    KAKAO,
+    NAVER,
+    GOOGLE,
+    NORMAL
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/entity/SocialInfo.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/entity/SocialInfo.java
@@ -1,0 +1,35 @@
+package com.spring.familymoments.domain.socialInfo.entity;
+
+import com.spring.familymoments.domain.common.BaseEntity;
+import com.spring.familymoments.domain.socialInfo.UserType;
+import com.spring.familymoments.domain.user.entity.User;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import javax.persistence.*;
+
+@EqualsAndHashCode(callSuper = false)
+@Entity
+@Table(name = "SocialInfo")
+@Setter
+@Getter
+@ToString
+@NoArgsConstructor(force = true)
+@AllArgsConstructor
+@Builder
+@DynamicInsert
+@DynamicUpdate
+public class SocialInfo extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "snsInfoId", nullable = false, updatable = false)
+    private Long snsInfoId;
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "user", nullable = false)
+    private User user;
+    @Column(name = "type", nullable = false, length = 10)
+    private UserType type = UserType.NORMAL;
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String snsUserId;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/entity/SocialInfo.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/entity/SocialInfo.java
@@ -32,4 +32,11 @@ public class SocialInfo extends BaseEntity {
     private UserType type = UserType.NORMAL;
     @Column(columnDefinition = "TEXT", nullable = false)
     private String snsUserId;
+
+    /**
+     * 회원 탈퇴 API 관련 메소드
+     */
+    public void updateStatus(Status status) {
+        this.status = status;
+    }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/google/GoogleAuthApi.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/google/GoogleAuthApi.java
@@ -1,0 +1,15 @@
+package com.spring.familymoments.domain.socialInfo.feign.google;
+
+import com.spring.familymoments.config.secret.FeignConfiguration;
+import com.spring.familymoments.domain.socialInfo.model.GoogleRequestAccessTokenDto;
+import com.spring.familymoments.domain.socialInfo.model.SocialAuthResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(value = "googleAuth", url = "https://oauth2.googleapis.com", configuration = FeignConfiguration.class)
+public interface GoogleAuthApi {
+    @PostMapping("/token")
+    ResponseEntity<SocialAuthResponse> getAccessToken(@RequestBody GoogleRequestAccessTokenDto requestDto);
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/google/GoogleAuthApi.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/google/GoogleAuthApi.java
@@ -1,15 +1,20 @@
 package com.spring.familymoments.domain.socialInfo.feign.google;
 
 import com.spring.familymoments.config.secret.FeignConfiguration;
+import com.spring.familymoments.domain.socialInfo.model.GoogleDeleteDto;
 import com.spring.familymoments.domain.socialInfo.model.GoogleRequestAccessTokenDto;
 import com.spring.familymoments.domain.socialInfo.model.SocialAuthResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(value = "googleAuth", url = "https://oauth2.googleapis.com", configuration = FeignConfiguration.class)
 public interface GoogleAuthApi {
     @PostMapping("/token")
     ResponseEntity<SocialAuthResponse> getAccessToken(@RequestBody GoogleRequestAccessTokenDto requestDto);
+
+    @PostMapping("/revoke")
+    ResponseEntity<String> unlink(@RequestBody GoogleDeleteDto googleDeleteDto);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/google/GoogleUserApi.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/google/GoogleUserApi.java
@@ -1,0 +1,14 @@
+package com.spring.familymoments.domain.socialInfo.feign.google;
+
+import com.spring.familymoments.config.secret.FeignConfiguration;
+import com.spring.familymoments.domain.socialInfo.model.GoogleLoginResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(value = "googleUser", url = "https://www.googleapis.com", configuration = FeignConfiguration.class)
+public interface GoogleUserApi {
+    @GetMapping("/userinfo/v2/me")
+    ResponseEntity<GoogleLoginResponse> getUserInfo(@RequestParam("access_token") String accessToken);
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/kakao/KakaoAuthApi.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/kakao/KakaoAuthApi.java
@@ -1,0 +1,20 @@
+package com.spring.familymoments.domain.socialInfo.feign.kakao;
+
+import com.spring.familymoments.config.secret.FeignConfiguration;
+import com.spring.familymoments.domain.socialInfo.model.SocialAuthResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@FeignClient(value = "kakaoAuth", url = "https://kauth.kakao.com", configuration = FeignConfiguration.class)
+public interface KakaoAuthApi {
+    @GetMapping("/oauth/token")
+    ResponseEntity<SocialAuthResponse> getAccessToken(
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("redirect_uri") String redirectUri,
+            @RequestParam("code") String authorizationCode
+    );
+
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/kakao/KakaoUserApi.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/kakao/KakaoUserApi.java
@@ -1,0 +1,16 @@
+package com.spring.familymoments.domain.socialInfo.feign.kakao;
+
+import com.spring.familymoments.config.secret.FeignConfiguration;
+import com.spring.familymoments.domain.socialInfo.model.KaKaoLoginResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.Map;
+
+@FeignClient(value = "kakoUser", url = "https://kapi.kakao.com", configuration = FeignConfiguration.class)
+public interface KakaoUserApi {
+    @GetMapping("/v2/user/me")
+    ResponseEntity<KaKaoLoginResponse> getUserInfo(@RequestHeader Map<String, String> header);
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/kakao/KakaoUserApi.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/kakao/KakaoUserApi.java
@@ -1,11 +1,11 @@
 package com.spring.familymoments.domain.socialInfo.feign.kakao;
 
 import com.spring.familymoments.config.secret.FeignConfiguration;
+import com.spring.familymoments.domain.socialInfo.model.KaKaoDeleteDto;
 import com.spring.familymoments.domain.socialInfo.model.KaKaoLoginResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -13,4 +13,8 @@ import java.util.Map;
 public interface KakaoUserApi {
     @GetMapping("/v2/user/me")
     ResponseEntity<KaKaoLoginResponse> getUserInfo(@RequestHeader Map<String, String> header);
+
+    @PostMapping("/v1/user/unlink")
+    ResponseEntity<String> unlink(@RequestHeader("Authorization") String authorization,
+                                  @RequestBody KaKaoDeleteDto kaKaoDeleteDto);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/naver/NaverAuthApi.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/naver/NaverAuthApi.java
@@ -1,0 +1,20 @@
+package com.spring.familymoments.domain.socialInfo.feign.naver;
+
+import com.spring.familymoments.config.secret.FeignConfiguration;
+import com.spring.familymoments.domain.socialInfo.model.SocialAuthResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(value = "naverAuth", url="https://nid.naver.com", configuration = FeignConfiguration.class)
+public interface NaverAuthApi {
+    @GetMapping("/oauth2.0/token")
+    ResponseEntity<SocialAuthResponse> getAccessToken(
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("code") String code,
+            @RequestParam("state") String state
+    );
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/naver/NaverUserApi.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/naver/NaverUserApi.java
@@ -1,0 +1,16 @@
+package com.spring.familymoments.domain.socialInfo.feign.naver;
+
+import com.spring.familymoments.config.secret.FeignConfiguration;
+import com.spring.familymoments.domain.socialInfo.model.NaverLoginResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.Map;
+
+@FeignClient(value = "naverUser", url = "https://openapi.naver.com", configuration = FeignConfiguration.class)
+public interface NaverUserApi {
+    @GetMapping("/v1/nid/me")
+    ResponseEntity<NaverLoginResponse> getUserInfo(@RequestHeader Map<String, String> header);
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/naver/NaverUserApi.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/feign/naver/NaverUserApi.java
@@ -6,6 +6,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.Map;
 
@@ -13,4 +14,11 @@ import java.util.Map;
 public interface NaverUserApi {
     @GetMapping("/v1/nid/me")
     ResponseEntity<NaverLoginResponse> getUserInfo(@RequestHeader Map<String, String> header);
+    @GetMapping("/v1/nid/me")
+    ResponseEntity<String> unlink(
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("access_token") String access_token,
+            @RequestParam("grant_type") String grantType //delete
+    );
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/GoogleDeleteDto.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/GoogleDeleteDto.java
@@ -1,0 +1,14 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GoogleDeleteDto {
+    private String token;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/GoogleLoginResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/GoogleLoginResponse.java
@@ -1,0 +1,18 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoogleLoginResponse {
+    private String id;
+    private String name;
+    private String picture;
+    //private String birthday; 구글의 다른 api로 정보 얻을 수 있음
+    private String email;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/GoogleRequestAccessTokenDto.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/GoogleRequestAccessTokenDto.java
@@ -1,0 +1,18 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GoogleRequestAccessTokenDto {
+    private String code;
+    private String client_id;
+    private String clientSecret;
+    private String redirect_uri;
+    private String grant_type;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/KaKaoDeleteDto.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/KaKaoDeleteDto.java
@@ -1,0 +1,15 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class KaKaoDeleteDto {
+    private String target_id_type;
+    private Long target_id;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/KaKaoLoginResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/KaKaoLoginResponse.java
@@ -1,0 +1,38 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KaKaoLoginResponse {
+    private String id;
+    @Builder.Default
+    private KakaoLoginData kakao_account = KakaoLoginData.builder().build();
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KakaoLoginData {
+        private String name;
+        @Builder.Default
+        private KakaoProfile profile = KakaoProfile.builder().build();
+        private String birthyear;
+        private String birthday;
+        private String email;
+
+        @Builder
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class KakaoProfile {
+            private String nickname;
+            private String profile_image_url;
+        }
+    }
+
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/LoginResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/LoginResponse.java
@@ -1,0 +1,16 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import com.spring.familymoments.config.secret.jwt.model.TokenDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class LoginResponse {
+    private TokenDto token;
+    private Long userId;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/NaverLoginResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/NaverLoginResponse.java
@@ -1,0 +1,31 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NaverLoginResponse {
+    private Response response = Response.builder().build();
+    private String resultCode;
+    private String message;
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Response {
+        private String id;
+        private String nickname;
+        private String name;
+        private String email;
+        private String birthday;
+        private String profile_image;
+        private String birthyear;
+    }
+
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialAuthResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialAuthResponse.java
@@ -1,0 +1,20 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class SocialAuthResponse {
+    //권한부여서버가 토큰을 주는 dto
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private String expires_in;
+    private String scope;
+    private String refresh_token_expires_in; //카카오만
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginOrJoinResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginOrJoinResponse.java
@@ -1,0 +1,35 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import com.spring.familymoments.config.secret.jwt.model.TokenDto;
+import lombok.*;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SocialLoginOrJoinResponse {
+    private LoginResponse loginResponse;
+    private JoinResponse joinResponse;
+    @Builder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LoginResponse {
+        private TokenDto tokenDto;
+    }
+    @Builder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class JoinResponse {
+        private String snsId;
+        private String name;
+        private String email;
+        private String strBirthDate;
+        private String nickname;
+        private String picture;
+    }
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginOrJoinResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginOrJoinResponse.java
@@ -1,6 +1,7 @@
 package com.spring.familymoments.domain.socialInfo.model;
 
 import com.spring.familymoments.config.secret.jwt.model.TokenDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Builder
@@ -8,6 +9,7 @@ import lombok.*;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "로그인(토큰을 발급)하거나 리소스 서버 정보들을 반환하는 Response")
 public class SocialLoginOrJoinResponse {
     private LoginResponse loginResponse;
     private JoinResponse joinResponse;
@@ -17,6 +19,7 @@ public class SocialLoginOrJoinResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class LoginResponse {
+        @Schema(description = "토큰", example = "eeeeeeeeee")
         private TokenDto tokenDto;
     }
     @Builder
@@ -25,11 +28,17 @@ public class SocialLoginOrJoinResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class JoinResponse {
+        @Schema(description = "소셜 고유 ID", example = "23231221421")
         private String snsId;
+        @Schema(description = "이름", example = "김영희")
         private String name;
+        @Schema(description = "이메일", example = "younghee@kakao.com")
         private String email;
+        @Schema(description = "생년월일", example = "20000101")
         private String strBirthDate;
+        @Schema(description = "닉네임", example = "영희엄마")
         private String nickname;
+        @Schema(description = "프로필 사진", example = "[url]")
         private String picture;
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginRequest.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginRequest.java
@@ -1,5 +1,6 @@
 package com.spring.familymoments.domain.socialInfo.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,10 +12,12 @@ import javax.validation.constraints.NotNull;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "소셜 서버(권한 부여 서버)에 인가코드(자격 증명)를 보내는 Request")
 public class SocialLoginRequest {
-    //사용자가 권한 부여 서버에게 자격 증명을 같이 보내는 단계
+    @Schema(description = "소셜 서버 종류", example = "KAKAO")
     @NotNull
     private String userType;
+    @Schema(description = "인가 코드", example = "yhgGywjpJXX8NaQJrgjN401U1VfW5__")
     @NotNull
     private String code;
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginRequest.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginRequest.java
@@ -1,0 +1,20 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SocialLoginRequest {
+    //사용자가 권한 부여 서버에게 자격 증명을 같이 보내는 단계
+    @NotNull
+    private String userType;
+    @NotNull
+    private String code;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialUserResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialUserResponse.java
@@ -1,0 +1,19 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import lombok.*;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@ToString
+public class SocialUserResponse {
+    //리소스 서버에서 가져온 정보들
+    private String snsId; //네.카.구. 식별자
+    private String name;
+    private String email;
+    private String birthyear;
+    private String birthday;
+    private String nickname;
+    private String picture;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/UserJoinRequest.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/UserJoinRequest.java
@@ -1,0 +1,19 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import lombok.*;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class UserJoinRequest {
+    private String userType;
+    private String id;
+    private String name;
+    private String email;
+    private String strBirthDate;
+    private String nickname;
+    private String profileImg;
+    private String snsId;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/UserJoinRequest.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/UserJoinRequest.java
@@ -1,5 +1,6 @@
 package com.spring.familymoments.domain.socialInfo.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Builder
@@ -7,13 +8,22 @@ import lombok.*;
 @NoArgsConstructor
 @Getter
 @Setter
+@Schema(description = "소셜 회원 등록하는 Request")
 public class UserJoinRequest {
+    @Schema(description = "소셜 서버 종류", example = "KAKAO")
     private String userType;
+    @Schema(description = "아이디", example = "younghee1234")
     private String id;
+    @Schema(description = "이름", example = "김영희")
     private String name;
+    @Schema(description = "이메일", example = "younghee@kakao.com")
     private String email;
+    @Schema(description = "생년월일", example = "20000101")
     private String strBirthDate;
+    @Schema(description = "닉네임", example = "영희엄마")
     private String nickname;
+    @Schema(description = "프로필 사진", example = "null(고정), 아래 profileImg에 등록 바람.")
     private String profileImg;
+    @Schema(description = "소셜 고유 ID", example = "23231221421")
     private String snsId;
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/UserJoinResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/UserJoinResponse.java
@@ -1,0 +1,18 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class UserJoinResponse {
+    private String id;
+    private String name;
+    private String strBirthDate;
+    private String nickname;
+    private String profileImg;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/UserLoginResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/UserLoginResponse.java
@@ -1,0 +1,14 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class UserLoginResponse {
+    private Long userId;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/UserResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/UserResponse.java
@@ -1,0 +1,17 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import lombok.*;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class UserResponse {
+    private Long userId;
+    private String id;
+    private String name;
+    private String email;
+    private String strBirthDate;
+    private String nickname;
+    private String profileImg;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthService.java
@@ -169,4 +169,16 @@ public class AuthService {
         long expiration = jwtService.getTokenExpirationTime(requestAccessTokenInHeader) - new Date().getTime();
         redisService.setValuesWithTimeout(requestAccessTokenInHeader, "logout", expiration);
     }
+
+    /**
+     * SocialToken(AT, RT)을 Redis에 저장 - 1
+     *
+     * Naver, Kakao, Google
+     */
+    @Transactional
+    public void saveSocialToken(String provider, String principal, String token, Long timeout) {
+        redisService.setValuesWithTimeout(provider + principal, //key
+                token, //value
+                timeout); //timeout(millis)
+    }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserDetailsService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserDetailsService.java
@@ -1,11 +1,12 @@
 package com.spring.familymoments.domain.user;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class UserDetailsService implements org.springframework.security.core.userdetails.UserDetailsService {
     /**
      * springsecurity에서 유저를 찾는 메소드를 제공하는 UserDetailsService를 implements
@@ -13,8 +14,7 @@ public class UserDetailsService implements org.springframework.security.core.use
      * 이 메소드의 username == '사용자 uuid'
      *
      */
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         return userRepository.findUserByUuid(username)

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
@@ -14,13 +14,13 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findUserByUserId(Long userId);
 
     Optional<User> findUserByUuid(String uuid);
 
     // Optional<User> findByEmailAndStatus(String email, BaseEntity.Status status);
     Optional<User> findById(String id);
     Optional<User> findByEmail(String email);
-    Optional<User> findByPassword(String password);
 
     boolean existsById(String id);
     boolean existsByName(String name);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -17,6 +17,7 @@ import com.spring.familymoments.domain.post.entity.Post;
 import com.spring.familymoments.domain.postLove.PostLoveRepository;
 import com.spring.familymoments.domain.postLove.entity.PostLove;
 import com.spring.familymoments.domain.redis.RedisService;
+import com.spring.familymoments.domain.socialInfo.SocialUserService;
 import com.spring.familymoments.domain.user.model.*;
 import com.spring.familymoments.domain.user.entity.User;
 import com.spring.familymoments.utils.UuidUtils;
@@ -57,6 +58,7 @@ public class UserService {
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
     private final RedisService redisService;
+    private final SocialUserService socialUserService;
 
     /**
      * createUser
@@ -336,6 +338,9 @@ public class UserService {
         //Redis에 탈퇴 처리한 AT 저장
         long expiration = jwtService.getTokenExpirationTime(requestAccessToken) - new Date().getTime();
         redisService.setValuesWithTimeout(requestAccessToken, "delete", expiration);
+
+        //소셜 회원 탈퇴 처리
+        socialUserService.deleteSocialUserWithRedisProcess(user);
     }
 
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?

- [x] 신규 기능 추가 : 

1.  소셜 로그인 API, 소셜 회원 가입 API `네이버` `카카오` `구글`
2.  회원 탈퇴 시 소셜 연동 끊기 기능 및 토큰 관리
3.  소셜 swagger 적용

- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

1️⃣ erd 수정 
socialInfo 테이블을 추가했습니다. 

2️⃣ build.gradle에 OpenFeign 라이브러리 추가 

외부 서버의 API를 호출하기 위해 RestTemplate 방식보다 생산성이 좋은 OpenFeign 방식을 적용했습니다.

3️⃣ 인터페이스를 활용해 선언과 구현을 분리 

네이버, 카카오, 구글 기능 구현에 공통으로 필요한 메소드를
`SocialLoginService` interface에 선언하고, 
`NaverLoginServiceImpl`, `KakaoLoginServiceImpl`, `GoogleLoginServiceImpl`, `LoginServiceImpl(default)`의 네 가지 구현체를 만들어 구현했습니다.

4️⃣ 소셜 Controller, Service, Repository 작성 

`SocialUserController` 
- 소셜 로그인 API (2가지 Response 형태): 
  기존 회원 대상 : 헤더와 쿠키로 토큰이 반환됩니다. 
  신규 회원 대상 : 사용자로부터 허용된 리소스 서버 정보들이 반환됩니다.
- 소셜 회원 가입 API:
  신규 회원 대상 : 얻은 리소스 서버 정보들과 사용자의 입력으로 유저를 등록하고 로그인(헤더와 쿠키로 토큰 발급)합니다.

`SocialUserService`, `SocialUserRepository`

5️⃣ 회원 탈퇴 시 소셜과의 연결 해제와 INACTIVE:

회원 탈퇴 시 소셜 AT로 연결을 해제했습니다. 
AT가 만료되었다면 exception이 발생하고 사용자에게 재로그인을 유도합니다.

그리고 탈퇴 후, 사용자가 다시 가입 하게 되면 
인가 서버(외부 서버)에서 동의 화면(ex 이메일, 이름, 생년월일, ..)을 다시 띄우는 것을 확인하여 
외부 서버로의 요청이 잘 작동되었다는 것을 확인할 수 있습니다.

(**TMI** : 연결 해제 API 호출도 공통 기능이라 생각해 네이버, 카카오, 구글을 묶으려 했으나 
카카오 연결 해제에서 요구되는 body 형태가 네이버, 구글과는 달라서 단순하게 구현했습니다.) 

6️⃣ swagger :
소셜 관련 2가지 API에 적용했습니다.

### 작업 후 기대 동작

API Sheet '소셜 로그인 API', '소셜 회원가입 API' 에서 postman 실행 결과 화면을 자세히 확인하실 수 있습니다. 🧡 

### PR 특이 사항

1. 추가 및 변경된 파일을 별도로 적용해야 합니다.
: FeignConfiguration.java 파일, application.xml 

2. (회의시간에 말한 것과 다르게) password를 nullable = false로 했습니다.
: @AuthenticationProvider 관련한 설정 시 password(PasswordEncoding이 되지 않은 순수한 형태)가 필수적으로 필요해서 소셜 로그인 시에도 password를 반드시 넣는 방식을 선택하였습니다. 보안상 password를 application.xml에 담았는데, 괜찮은지 궁금합니다.

리뷰 부탁드립니다 ~ 💟 
