### PR TITLE
feat: 파일 업로드 용량 초과 에러 예외 처리

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/advice/ExceptionAdvice.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/advice/ExceptionAdvice.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
@@ -68,6 +69,12 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         BaseResponse<Object> baseResponse = new BaseResponse<>(false, errorMessage, HttpStatus.BAD_REQUEST.value());
 
         return handleExceptionInternal(ex, baseResponse, new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
+    }
+
+    /** 파일 업로드 용량 초과 에러 **/
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    protected BaseResponse<Object> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException ex) {
+        return new BaseResponse<>(false, "Max Request Upload Size Exceeded", HttpStatus.PAYLOAD_TOO_LARGE.value());
     }
 
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 파일 업로드 용량 초과 예외 처리 추가
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 찾아보니까 해당 에러도 일반적으로 예외처리를 하고 있어 추가했습니다.

### 작업 후 기대 동작(스크린샷)

- 파일 업로드 시, 용량이 클 때 발생하는 에러 예외 처리
![image](https://github.com/familymoments/family-moments-BE/assets/68217805/4f0b222a-1020-4750-bda5-2a8712b9d619)
