### PR TITLE
Fix : 토큰 재발급 api, 로그아웃 api 버그 수정

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthController.java
@@ -1,6 +1,7 @@
 package com.spring.familymoments.domain.user;
 
 import com.spring.familymoments.config.BaseResponse;
+import com.spring.familymoments.config.NoAuthCheck;
 import com.spring.familymoments.config.secret.jwt.JwtSecret;
 import com.spring.familymoments.config.secret.jwt.model.TokenDto;
 import com.spring.familymoments.domain.user.model.PostLoginReq;
@@ -81,13 +82,14 @@ public class AuthController {
 
     /**
      * 토큰 재발급 API
-     * [POST] /users/auth/reissue
+     * [POST] /users/reissue
      * return 200
      *      [header] Cookie : "refresh-token=e~~~" (refresh-token)
      *               X-AUTH-TOKEN : e~~~ (access-token)
      * return 471
      *      [header] Cookie : "refresh-token=(empty)" (refresh-token)
      */
+    @NoAuthCheck
     @PostMapping(value = "/users/reissue", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "토큰 재발급", description = "토큰을 재발급합니다.")
     @ApiResponses(value = {

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import static com.spring.familymoments.config.BaseResponseStatus.INVALID_USER_JWT;
+import static com.spring.familymoments.config.BaseResponseStatus.SUCCESS;
 
 @Controller
 @RequiredArgsConstructor
@@ -131,17 +131,13 @@ public class AuthController {
     @Operation(summary = "로그아웃", description = "쿠키의 내용 지우면서 로그아웃합니다.")
     @ApiResponse(responseCode = "200", description = "OK")
     public ResponseEntity<?> logout(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken) {
-        try {
-            authService.logout(requestAccessToken);
-            ResponseCookie responseCookie = ResponseCookie.from("refresh-token", "")
-                    .maxAge(0)
-                    .path("/")
-                    .build();
-            return ResponseEntity.status(HttpStatus.OK)
-                    .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
-                    .build();
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().body(new BaseResponse(INVALID_USER_JWT));
-        }
+        authService.logout(requestAccessToken);
+        ResponseCookie responseCookie = ResponseCookie.from("refresh-token", "")
+                .maxAge(0)
+                .path("/")
+                .build();
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .body(new BaseResponse<>(SUCCESS));
     }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 토큰 재발급 api, 로그아웃 api
- [ ] 리펙토링 : 
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 토큰 재발급 api :
    - `문제` : authcheck 어노테이션이 부재해서 해당 api에서 **불필요한 461 에러 발생**
       - (해당 api에서 461 에러 불필요한 이유 : 461에러 발생 시에만 호출되는 api이기 때문)
    - `해결` : authcheck 어노테이션 추가
- 로그아웃 api :
    - `문제` : 오류 상황에서도 200 OK가 발생 (즉, 200 OK와 에러 상황 구별 모호)
        - 200 OK
        ![image](https://github.com/familymoments/family-moments-BE/assets/97500298/5ae2daf4-be0f-4a51-806d-81b550691124)
        - 403 error (blacklist)
        ![스크린샷 2024-03-19 234436](https://github.com/familymoments/family-moments-BE/assets/97500298/50f96ef7-3beb-4af3-9014-f1e4bc181d50)

    - `해결` :  status code 포함한 response body 추가 
              ![image](https://github.com/familymoments/family-moments-BE/assets/97500298/cab718d4-21ca-4435-b066-78553dd05b5d)
      
    + 리펙토링 : auth intercepter와 중복되는 exception 제거


