### PR TITLE
feat: 가족 정보 수정 api

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
@@ -3,7 +3,6 @@ package com.spring.familymoments.domain.family;
 import com.spring.familymoments.config.BaseException;
 import com.spring.familymoments.config.BaseResponse;
 import com.spring.familymoments.config.NoAuthCheck;
-import com.spring.familymoments.config.secret.jwt.JwtService;
 import com.spring.familymoments.domain.awsS3.AwsS3Service;
 import com.spring.familymoments.domain.family.model.*;
 import com.spring.familymoments.domain.user.AuthService;
@@ -16,8 +15,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -28,8 +25,6 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.validation.Valid;
 import java.util.List;
 import java.util.Map;
-
-import static com.spring.familymoments.config.BaseResponseStatus.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -49,7 +44,6 @@ public class FamilyController {
      * @return BaseResponse<PostFamilyRes>
      */
     @ResponseBody
-    @NoAuthCheck
     @PostMapping("/family")
     @Operation(summary = "가족 생성", description = "가족 그룹을 생성합니다.")
     public BaseResponse<PostFamilyRes> createFamily(

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
@@ -215,12 +215,13 @@ public class FamilyController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK"),
     })
-    @PatchMapping(value ="/{familyId}/update", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PatchMapping(value ="/{familyId}/update",  consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public BaseResponse<FamilyRes> updateFamily(@PathVariable Long familyId,
-                                                @AuthenticationPrincipal @Parameter(hidden = true) User user,
-                                                @Valid @RequestBody FamilyUpdateRes familyUpdateRes){
-        FamilyRes resFamilyRes = familyService.updateFamily(user, familyId, familyUpdateRes);
-        return new BaseResponse<>(resFamilyRes);
+                                                @RequestParam(name = "representImg") MultipartFile representImg,
+                                                @Valid @RequestPart FamilyUpdateReq familyUpdateReq){
+        String fileUrl = awsS3Service.uploadImage(representImg);
+        FamilyRes familyRes = familyService.updateFamily(familyId, familyUpdateReq, fileUrl);
+        return new BaseResponse<>(familyRes);
     }
 
     /** 가족 탈퇴 API

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
@@ -44,7 +44,8 @@ public class FamilyController {
      * @return BaseResponse<PostFamilyRes>
      */
     @ResponseBody
-    @PostMapping("/family")
+    @NoAuthCheck
+    @PostMapping(value ="/family", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "가족 생성", description = "가족 그룹을 생성합니다.")
     public BaseResponse<PostFamilyRes> createFamily(
             @AuthenticationPrincipal @Parameter(hidden = true) User user,

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
@@ -232,17 +232,11 @@ public class FamilyService {
 
     //가족 정보 수정
     @Transactional
-    public FamilyRes updateFamily(User user, Long familyId, FamilyUpdateRes familyUpdateRes){
+    public FamilyRes updateFamily(Long familyId, FamilyUpdateReq familyUpdateReq, String fileUrl){
         Family family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new BaseException(FIND_FAIL_FAMILY));
-        User userToOwner = userRepository.findById(familyUpdateRes.getOwner())
-                .orElseThrow(() -> new BaseException(FIND_FAIL_USER));
 
-        if(!user.equals(family.getOwner())){
-            throw new BaseException("권한이 없습니다.", HttpStatus.UNAUTHORIZED.value());
-        }
-
-        family.updateFamily(userToOwner, familyUpdateRes.getFamilyName());
+        family.updateFamily(familyUpdateReq.getFamilyName(), fileUrl);
         familyRepository.save(family);
 
         return family.toFamilyRes();

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/entity/Family.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/entity/Family.java
@@ -53,6 +53,7 @@ public class Family extends BaseEntity {
 
     public FamilyRes toFamilyRes(){
         return FamilyRes.builder()
+                .familyId(familyId)
                 .owner(owner.getNickname())
                 .familyName(familyName)
                 .uploadCycle(uploadCycle)
@@ -76,12 +77,9 @@ public class Family extends BaseEntity {
         this.uploadCycle = uploadCycle;
     }
 
-    /**
-     * 가족 정보 수정 API 관련 메소드
-     */
-    public void updateFamily(User owner, String familyName) {
-        this.owner = owner;
+    public void updateFamily(String familyName, String representImg){
         this.familyName = familyName;
+        this.representImg = representImg;
     }
 
     /**

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/model/FamilyUpdateReq.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/model/FamilyUpdateReq.java
@@ -4,17 +4,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
 
 @Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Schema(description = "가족 정보 수정 Request")
-public class FamilyUpdateRes {
+public class FamilyUpdateReq {
 
-    @Schema(description = "가족 권한자")
-    private String owner;
-
+    @Size(max = 20, message = "가족 이름은 20자 이하입니다")
     @NotEmpty(message = "가족 이름을 입력해주세요.")
     private String familyName;
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/model/PostFamilyReq.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/model/PostFamilyReq.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 
 @Getter
 @Setter
@@ -15,6 +16,7 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 @Schema(description = "가족 생성 관련 Request")
 public class PostFamilyReq {
+    @Size(max = 20, message = "가족 이름은 20자 이하입니다")
     @NotBlank(message = "가족 이름을 입력해주세요.")
     @Schema(description = "가족 이름" , example = "FamilyMoments")
     private String familyName;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 가족 정보 수정 api
- [x] 버그 수정 : 가족생성api noAuthCheck 제거
- [x] 리펙토링 : 가족 생성 api consumes, produces 추가,  가족 생성 시 글자수 제한 validation 추가
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
1. 가족 정보 수정 api
    - 가족 이름, 가족 이미지 수정
2. 가족 생성 api noAuthCheck 제거
    - 인증이 필요한 api 이므로 제거
3. 가족 생성 api consumes, produces 추가
    - 스웨거 사용을 위해 추가
4. 가족 생성 시 글자수 제한 validation 추가
    - 해당 validation 없이 제한을 넘은 요청이 들어오면 500 error 발생할 수 있음
