### PR TITLE
feat : 모바일 SDK 버전 네이버/카카오 API 및 리펙토링, fix : 회원정보조회API 

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -48,6 +48,7 @@ public enum BaseResponseStatus {
     FAILED_TO_LOGIN_PWD(false,HttpStatus.NOT_FOUND.value(),"비밀번호가 일치하지 않습니다."),
     FAILED_TO_LOGIN(false,HttpStatus.NOT_FOUND.value(), "탈퇴하거나 신고당한 유저입니다."),
     FIND_FAIL_FAMILY(false, HttpStatus.NOT_FOUND.value(), "존재하지 않는 가족입니다."),
+    NEED_TO_JOIN_AS_THIS_SOCIAL(false, 481, "해당 소셜로 회원 가입을 해야 합니다."),
     FAILED_INVITE_USER_FAMILY(false, HttpStatus.CONFLICT.value(), "이미 가족에 가입된 회원입니다."),
     FAMILY_LIMIT_EXCEEDED(false, HttpStatus.CONFLICT.value(), "가족은 최대 5개까지만 가능합니다."),
     FAILED_SOCIAL_JOIN(false, HttpStatus.CONFLICT.value(), "이미 해당 소셜 계정이 있는 회원입니다."),

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostWithUserRepository.java
@@ -13,8 +13,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 public interface PostWithUserRepository extends JpaRepository<Post, Long> {
-    //현재 가족에서의 내 게시글 업로드 수
-    Long countByWriterAndFamilyId(User user, Family family);
+    //현재 가족에서의 내 게시글 업로드 수 (active)
+    @Query("SELECT count(*) FROM Post p WHERE p.writer = :user AND p.familyId = :family AND p.status = 'ACTIVE'")
+    Long countActivePostsByWriterAndFamily(@Param("user") User user, @Param("family") Family family);
+
     //유저가 작성한 모든 게시글 조회
     @Query("SELECT p FROM Post p WHERE p.writer.userId = :userId")
     List<Post> findPostByUserId(@Param("userId")Long userId);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserRepository.java
@@ -11,7 +11,13 @@ import java.util.List;
 
 @Repository
 public interface SocialUserRepository extends JpaRepository<SocialInfo, Long> {
+    //rest api version
     @Query("SELECT u FROM User u LEFT JOIN SocialInfo si ON u = si.user WHERE u.email = :email AND si.type = :userType")
     User findUserByEmailAndUserType(@Param("email") String email, @Param("userType") UserType userType);
+
+    //sdk version
+    @Query("SELECT u FROM User u LEFT JOIN SocialInfo si ON u= si.user WHERE u.email = :email AND si.snsUserId = :snsId")
+    User findUserByEmailAndSnsId(@Param("email") String email, @Param("snsId") String snsId);
+
     List<SocialInfo> findSocialInfoByUser(User user);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginSdkRequest.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginSdkRequest.java
@@ -1,0 +1,20 @@
+package com.spring.familymoments.domain.socialInfo.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "소셜 가입 여부 확인 Request")
+public class SocialLoginSdkRequest {
+    @Schema(description = "소셜 고유 ID", example = "23231221421")
+    private String snsId;
+
+    @Schema(description = "이메일", example = "younghee@naver.com")
+    private String email;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -151,7 +151,7 @@ public class UserService {
         Long totalUpload = 0L;
         if(familyId != null) {
             Family family = familyRepository.findById(familyId).orElseThrow(() -> new BaseException(FIND_FAIL_FAMILY));
-            totalUpload = postWithUserRepository.countByWriterAndFamilyId(user, family);
+            totalUpload = postWithUserRepository.countActivePostsByWriterAndFamily(user, family);
         }
 
         String formatPattern = "yyyyMMdd"; //생년월일


### PR DESCRIPTION
### 무엇을 위한 PR인가요?

- [x] 신규 기능 추가 : 모바일 SDK 버전 네이버/카카오 API
- [x] 버그 수정 : 회원정보조회API
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 모바일 SDK 버전 네이버/카카오 API : 
  웹이 아닌 네이티브 앱에서는 프론트가 개발자 환경 세팅부터 token을 발급하는 과정 모두 진행함.

- 회원정보조회API :
   글이 삭제돼도 회원정보조회API에서 글 개수가 줄어들지 않는 문제 

### 작업 내역

- 모바일 SDK 버전 네이버/카카오 API : 
  우리 서비스는 자체 토큰을 발급해주기 때문에 카카오/네이버 토큰을 서버에 저장할 필요 없어짐.
  해당 소셜(네이버/카카오)로 이미 가입한 회원인지의 여부만 확인해주고 
  회원은 바로 로그인 시키고, 비회원은 가입하게 하면 됨.
  
- 회원정보조회API :
   active 시 조건 추가

### 작업 후 기대 동작(스크린샷)

- 모바일 SDK 버전 네이버/카카오 API : 
  - 성공
  ![Untitled](https://github.com/familymoments/family-moments-BE/assets/97500298/1cf79727-61fe-4fb4-ad0a-f760e502a516)
  - 비회원 시 481에러 반환
  ![image](https://github.com/familymoments/family-moments-BE/assets/97500298/6eba30e0-382a-481b-9a0f-2c4c9c2ac874)
