### PR TITLE
fix: 가족 생성일 조회 시, 부정확한 값 반납 오류 해결

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
@@ -92,12 +92,8 @@ public class FamilyController {
     public BaseResponse<GetFamilyCreatedNicknameRes> getFamilyCreatedNickname(
             @AuthenticationPrincipal @Parameter(hidden = true) User user,
             @PathVariable Long familyId) {
-        try {
-            GetFamilyCreatedNicknameRes getFamilyCreatedNicknameRes = familyService.getFamilyCreatedNickname(user, familyId);
-            return new BaseResponse<>(getFamilyCreatedNicknameRes);
-        } catch (BaseException e) {
-            return new BaseResponse<>((e.getStatus()));
-        }
+        GetFamilyCreatedNicknameRes getFamilyCreatedNicknameRes = familyService.getFamilyCreatedNickname(user, familyId);
+        return new BaseResponse<>(getFamilyCreatedNicknameRes);
     }
 
     /**

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
@@ -1,12 +1,13 @@
 package com.spring.familymoments.domain.family;
 
 import com.spring.familymoments.domain.family.entity.Family;
+import com.spring.familymoments.domain.family.model.GetFamilyCreatedNicknameRes;
 import com.spring.familymoments.domain.user.entity.User;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,5 +26,12 @@ public interface FamilyRepository extends JpaRepository<Family, Long> {
 
     @Query("SELECT f FROM Family f JOIN f.userFamilies uf WHERE uf.userId = :user AND uf.status = 'ACTIVE' ORDER BY uf.createdAt ASC")
     List<Family> findActiveFamilyByUserId(@Param("user") User user);
+
+    @Query(value = "SELECT DATEDIFF(:today, f.createdAt)  " +
+            "FROM Family f " +
+            "WHERE f.familyId = :familyId " +
+            "AND f.status = 'ACTIVE' ",
+            nativeQuery = true)
+    String findCreatedAtNicknameById(@Param("familyId") Long familyId, @Param("today") LocalDateTime today);
 
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
@@ -106,22 +107,13 @@ public class FamilyService {
 
     // 닉네임 및 가족 생성일 조회
     @Transactional
-    public GetFamilyCreatedNicknameRes getFamilyCreatedNickname(User user, Long familyId) throws BaseException{
-
-//        User user = userRepository.findById(userId)
-//                .orElseThrow(() -> new BaseException(FIND_FAIL_USERNAME));
-
-        Family family = familyRepository.findById(familyId)
-                .orElseThrow(() -> new BaseException(FIND_FAIL_FAMILY));
-
-        LocalDate createdAt = family.getCreatedAt().toLocalDate();
-        LocalDate now = LocalDate.now();
-
-        Period period = Period.between(createdAt, now);
-
-        String daysSinceCreation = String.valueOf(period.getDays()+1);
-
-        return new GetFamilyCreatedNicknameRes(user.getNickname(), daysSinceCreation);
+    public GetFamilyCreatedNicknameRes getFamilyCreatedNickname(User user, Long familyId) {
+        LocalDateTime today = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
+        String dday = familyRepository.findCreatedAtNicknameById(familyId, today);
+        if (dday == null) {
+            throw new BaseException("가족 생성일을 찾을 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value());
+        }
+        return new GetFamilyCreatedNicknameRes(user.getNickname(), dday);
     }
 
     // 가족원 전체 조회


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 : 
- [x] 버그 수정 : 가족 성일로부터 d+day 계산이 제대로 이루어지지않는 부분을 해결했습니다.
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 가족 생성일 조회 시, 부정확한 값 반납 오류 해결

### 작업 후 기대 동작(스크린샷)

- 가족 DB
![image](https://github.com/familymoments/family-moments-BE/assets/63528205/079e6504-c051-4b24-bd7c-c15b51026bbe)

- 현재 날짜를 기준으로 D+day 계산한 결과
![image](https://github.com/familymoments/family-moments-BE/assets/63528205/fc168450-54cb-4b7f-938b-c8addf0687b3)

- Postman 조회 성공
![image](https://github.com/familymoments/family-moments-BE/assets/63528205/a884e7a4-88dc-4120-8f13-bea4bc74083d)

- Postman 존재하지 않는 가족 조회시
![image](https://github.com/familymoments/family-moments-BE/assets/63528205/3849322d-a377-4457-970b-4b04c0373db4)

