### PR TITLE
fix: 초대코드로 조회 시 familyId가 null인 문제

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/entity/Family.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/entity/Family.java
@@ -60,6 +60,7 @@ public class Family extends BaseEntity {
 
     public FamilyRes toFamilyRes(){
         return FamilyRes.builder()
+                .familyId(familyId)
                 .owner(owner.getNickname())
                 .familyName(familyName)
                 .uploadCycle(uploadCycle)


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 초대 코드로 가족 조회 시 familyId 값이 null 인 문제
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 


### 작업 후 기대 동작(스크린샷)

![image](https://github.com/familymoments/family-moments-BE/assets/68217805/6ffb85da-5eea-4f9c-9822-d021f2966083)
