### PR TITLE
fix: 본인 인증 메일 발송

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -41,6 +41,7 @@ public enum BaseResponseStatus {
     POST_USERS_EMPTY_NICKNAME(false, HttpStatus.BAD_REQUEST.value(), "닉네임을 입력해주세요."),
     POST_USERS_INVALID_NICKNAME(false, HttpStatus.BAD_REQUEST.value(), "닉네임 형식을 확인해주세요."),
     NOT_EQUAL_VERIFICATION_CODE(false, HttpStatus.BAD_REQUEST.value(), "인증 번호가 일치하지 않습니다."),
+    VERIFICATION_TIME_EXPIRED(false, HttpStatus.BAD_REQUEST.value(), "인증 유효 시간이 만료되었습니다. 다시 인증을 요청해주세요."),
     FIND_FAIL_USER_NAME_EMAIL(false,HttpStatus.NOT_FOUND.value(), "이름과 이메일이 정확히 입력되었는지 확인해주세요."),
     FIND_FAIL_ID(false, HttpStatus.NOT_FOUND.value(), "입력한 아이디와 일치하는 회원정보가 없습니다."),
     FIND_FAIL_INVITATION(false, HttpStatus.NOT_FOUND.value(), "초대 요청 목록이 존재하지 않습니다."),

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailService.java
@@ -1,6 +1,7 @@
 package com.spring.familymoments.domain.user;
 
 import com.spring.familymoments.config.BaseException;
+import com.spring.familymoments.domain.redis.RedisService;
 import com.spring.familymoments.domain.user.entity.User;
 import com.spring.familymoments.domain.user.model.GetUserIdRes;
 import com.spring.familymoments.domain.user.model.PostEmailReq;
@@ -16,7 +17,7 @@ import javax.mail.internet.MimeMessage;
 import java.io.UnsupportedEncodingException;
 import java.util.Objects;
 
-import static com.spring.familymoments.config.BaseResponseStatus.FIND_FAIL_USER_EMAIL;
+import static com.spring.familymoments.config.BaseResponseStatus.*;
 
 @Slf4j
 @Service
@@ -25,6 +26,8 @@ public class EmailService {
 
     private final UserRepository userRepository;
 
+    private final RedisService redisService;
+    
     private final JavaMailSender emailSender;
 
     private String randomVerificationCode;
@@ -34,8 +37,11 @@ public class EmailService {
      *
      * @return String
      */
-    public String createRandomCode(){
+    public String createRandomCode(String email){
         randomVerificationCode = RandomStringUtils.random(6, 33, 125, false, true);
+        int CODE_EXPIRATION_TIME = 3 * 60 * 1000; // 인증 코드 유효 시간: 3분
+
+        redisService.setValuesWithTimeout("VC(" + email + "):", randomVerificationCode, CODE_EXPIRATION_TIME);
 
         return randomVerificationCode;
     }
@@ -47,7 +53,7 @@ public class EmailService {
      */
     public MimeMessage createEmailForm(String email) throws MessagingException, UnsupportedEncodingException {
 
-        createRandomCode();
+        createRandomCode(email);
 
         String emailReceiver = email; //받는 사람
         String title = "Family Moments 본인 인증 번호";
@@ -102,6 +108,8 @@ public class EmailService {
     public boolean checkVerificationCode(PostEmailReq.sendVerificationEmail req) {
 
         // randomVerificationCode = emailService.sendEmail(req.getName(), req.getEmail());
+        randomVerificationCode = redisService.getValues("VC("+ req.getEmail() + "):");
+
         return Objects.equals(req.getCode(), randomVerificationCode);
     }
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [X] 버그 수정 : 본인 인증 메일 발송 로직 수정 (Redis 적용, #73)
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

![image](https://github.com/familymoments/family-moments-BE/assets/55887179/6ef6421c-7354-45ef-a971-1cb3b088b276)

- A 유저: 파란색 옷을 입은 사람, B 유저: 초록새 옷을 입은 사람
- `RedisService`의 함수들을 이용하여 이메일과 인증코드를 { key, value } 형태로 저장

### 작업 내역

- `RedisService`의 함수들을 이용하여 이메일과 인증코드를 { key, value } 형태로 저장 

### 작업 후 기대 동작(스크린샷)

![image](https://github.com/familymoments/family-moments-BE/assets/55887179/44a8457d-b6c6-4878-af63-e50b950aa9e3)

- Redis에 { key, value } 형태로 이메일과 인증코드가 저장
- 인증 유효 시간은 3분
- 기존 오류 해결 관련은 노션 페이지에 작성

### 어떤 부분에 리뷰어가 집중하면 좋을까요?

- 추후 유효 시간 만료 기능 개발 예정
