### PR TITLE
fix: 본인의 게시물 여부를 반환하는 변수 추가

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -88,7 +88,8 @@ public enum BaseResponseStatus {
     ALREADY_DELETE_COMMENT(false, HttpStatus.NOT_FOUND.value(), "이미 삭제된 댓글입니다."),
     COMMENTS_EMPTY_CONTENT(false, HttpStatus.NOT_FOUND.value(), "댓글 내용을 입력해주세요."),
 
-    minnie_POSTS_INVALID_USER(false, HttpStatus.FORBIDDEN.value(), "수정 권한이 없습니다."),
+    minnie_POSTS_EDIT_INVALID_USER(false, HttpStatus.FORBIDDEN.value(), "수정 권한이 없습니다."),
+    minnie_POSTS_DELETE_INVALID_USER(false, HttpStatus.FORBIDDEN.value(), "삭제 권한이 없습니다."),
     minnie_POSTS_INVALID_POST_ID(false, HttpStatus.NOT_FOUND.value(), "유효하지 않은 postId 입니다."),
     minnie_POSTS_NON_EXISTS_POST(false, HttpStatus.NOT_FOUND.value(), "post가 존재하지 않습니다."),
     minnie_POSTS_EMPTY_UPDATE(false, HttpStatus.BAD_REQUEST.value(), "수정할 내용을 보내주세요."),

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -69,7 +69,7 @@ public class PostController {
                 .build();
 
         try {
-            SinglePostRes singlePostRes = postService.createPosts(user, postReq);
+            SinglePostRes singlePostRes = postService.createPost(user, postReq);
             return new BaseResponse<>(singlePostRes);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
@@ -138,7 +138,7 @@ public class PostController {
     @Operation(summary = "게시글 10건 조회", description = "최근 10개의 게시글을 조회합니다.")
     public BaseResponse<List<SinglePostRes>> getRecentPosts(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestParam("familyId") long familyId) {
         try {
-            List<SinglePostRes> singlePostRes = postService.getPosts(user.getUserId(), familyId);
+            List<SinglePostRes> singlePostRes = postService.getPosts(user, familyId);
             return new BaseResponse<>(singlePostRes);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
@@ -155,7 +155,7 @@ public class PostController {
     @Operation(summary = "게시글 수정(with paging)", description = "커서 이전의 게시물 10건을 조회합니다.")
     public BaseResponse<List<SinglePostRes>> getNextPosts(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestParam("familyId") long familyId, @RequestParam("postId") long postId) {
         try {
-            List<SinglePostRes> singlePostRes = postService.getPosts(user.getUserId(), familyId, postId);
+            List<SinglePostRes> singlePostRes = postService.getPosts(user, familyId, postId);
             return new BaseResponse<>(singlePostRes);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
@@ -172,7 +172,7 @@ public class PostController {
     @Operation(summary = "게시글 조회", description = "게시글 1건을 조회합니다.")
     public BaseResponse<SinglePostRes> getPost(@AuthenticationPrincipal @Parameter(hidden = true) User user, @PathVariable long postId) {
         try {
-            SinglePostRes singlePostRes = postService.getPost(user.getUserId(), postId);
+            SinglePostRes singlePostRes = postService.getPost(user, postId);
 
             return new BaseResponse<>(singlePostRes);
         } catch (BaseException e) {
@@ -194,7 +194,7 @@ public class PostController {
                                                               @RequestParam("month") int month,
                                                               @RequestParam("day") int day) {
         try {
-            List<SinglePostRes> singlePostRes = postService.getPostsOfDate(user.getUserId(), familyId, year, month, day);
+            List<SinglePostRes> singlePostRes = postService.getPostsOfDate(user, familyId, year, month, day);
             return new BaseResponse<>(singlePostRes);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
@@ -216,7 +216,7 @@ public class PostController {
                                                               @RequestParam("day") int day,
                                                               @RequestParam("postId") long postId) {
         try {
-            List<SinglePostRes> singlePostRes = postService.getPostsOfDate(user.getUserId(), familyId, year, month, day, postId);
+            List<SinglePostRes> singlePostRes = postService.getPostsOfDate(user, familyId, year, month, day, postId);
             return new BaseResponse<>(singlePostRes);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -53,11 +53,10 @@ public class PostService {
         List<String> urls = awsS3Service.uploadImages(postReq.getImgs());
 
         // Post builder 생성
-        Post.PostBuilder postBuilder = Post.builder()
-                .writer(user).familyId(family);
-
-        // build
-        Post params = postBuilder.build();
+        Post params = Post.builder()
+                .writer(user)
+                .familyId(family)
+                .build();
 
         Post result = postRepository.save(params);
 
@@ -71,13 +70,11 @@ public class PostService {
         family.updateLatestUploadAt();
 
         // PostDocument builder 생성
-        PostDocument.PostDocumentBuilder postDocumentBuilder = PostDocument.builder()
+        PostDocument docParams = PostDocument.builder()
                 .entityId(result.getPostId())
                 .content(postReq.getContent())
-                .urls(urls);
-
-        // build
-        PostDocument docParams = postDocumentBuilder.build();
+                .urls(urls)
+                .build();
 
         PostDocument docResult = postDocumentRepository.save(docParams);
 
@@ -97,7 +94,7 @@ public class PostService {
                 .countLove(0).loved(false) // 새로 생성된 Post 이므로 default return
                 .written(true) // 새로 생성된 Post 이므로 default return
                 .build();
-        
+
         // 새로 만들어진 객체 반환
         return singlePostRes;
     }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -32,14 +32,14 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostDocumentRepository postDocumentRepository;
     private final PostLoveService postLoveService;
-    private final AwsS3Service awsS3Service;
     private final FamilyRepository familyRepository;
+    private final AwsS3Service awsS3Service;
 
     private static final int POST_PAGES = 10;
     private static final int ALBUM_PAGES = 30;
 
     @Transactional
-    public SinglePostRes createPosts(User user, PostReq postReq) {
+    public SinglePostRes createPost(User user, PostReq postReq) {
         // familyID 유효성 검사
         Family family = familyRepository.findById(postReq.getFamilyId())
                 .orElseThrow(() -> new BaseException(FIND_FAIL_FAMILY));
@@ -94,7 +94,8 @@ public class PostService {
                 .content(docResult.getContent())
                 .imgs(docResult.getUrls())
                 .createdAt(result.getCreatedAt().toLocalDate())
-                .countLove(0).loved(false) // 새로 생성된 정보이므로 default return
+                .countLove(0).loved(false) // 새로 생성된 Post 이므로 default return
+                .written(true) // 새로 생성된 Post 이므로 default return
                 .build();
         
         // 새로 만들어진 객체 반환
@@ -113,7 +114,7 @@ public class PostService {
         }
 
         if(!Objects.equals(editedPost.getWriter().getUserId(), user.getUserId())) {
-            throw new BaseException(minnie_POSTS_INVALID_USER);
+            throw new BaseException(minnie_POSTS_EDIT_INVALID_USER);
         }
 
         // 수정할 Post Document 정보 불러오기
@@ -153,6 +154,7 @@ public class PostService {
         });
 
         boolean isLoved = postLoveService.checkPostLoveByUser(editedPost.getPostId(), editedPost.getWriter().getUserId());
+        boolean isWritten = editedPost.isWriter(user);
 
         SinglePostDocumentRes singlePostDocumentRes = SinglePostDocumentRes.builder()
                 .content(postReq.getContent())
@@ -166,7 +168,7 @@ public class PostService {
                 editedPost.getWriter().getProfileImg(),
                 editedPost.getCreatedAt(),
                 editedPost.getCountLove(),
-                isLoved, singlePostDocumentRes
+                isLoved, isWritten, singlePostDocumentRes
         );
     }
 
@@ -184,7 +186,7 @@ public class PostService {
         }
 
         if(!deletedPost.getWriter().getUserId().equals(user.getUserId())) {
-            throw new BaseException(minnie_POSTS_INVALID_USER);
+            throw new BaseException(minnie_POSTS_DELETE_INVALID_USER);
         }
 
         deletedPost.delete();
@@ -193,17 +195,17 @@ public class PostService {
 
     // 현재 가족의 모든 게시물 중 최근 10개를 조회
     @Transactional(readOnly = true)
-    public List<SinglePostRes> getPosts(long userId, long familyId) {
+    public List<SinglePostRes> getPosts(User user, long familyId) {
         Pageable pageable = PageRequest.of(0, POST_PAGES);
 
-        List<SinglePostRes> posts = getCombinedPosts(familyId, pageable);
+        List<SinglePostRes> posts = getCombinedPosts(user, familyId, pageable);
 
         return posts;
     }
 
     // 현재 가족의 모든 게시물 중 특정 postId 보다 작은 10개를 조회
     @Transactional(readOnly = true)
-    public List<SinglePostRes> getPosts(long userId, long familyId, long postId) {
+    public List<SinglePostRes> getPosts(User user, long familyId, long postId) {
         Pageable pageable = PageRequest.of(0, POST_PAGES);
         List<Post> filteredPosts = postRepository.findByFamilyIdAfterPostId(familyId, postId, pageable);
 
@@ -215,6 +217,7 @@ public class PostService {
         for(Post p: filteredPosts){
             SinglePostDocumentRes singlePostDocumentRes = postDocumentRepository.findByEntityId(p.getPostId());
             boolean isLoved = postLoveService.checkPostLoveByUser(p.getPostId(), p.getWriter().getUserId());
+            boolean isWritten = p.isWriter(user);
 
             Long filteredPostId = p.getPostId();
             String writer = p.getWriter().getNickname();
@@ -223,7 +226,7 @@ public class PostService {
             int countLove = p.getCountLove();
 
             SinglePostRes singlePostRes = toSinglePostRes(filteredPostId, writer, profileImg,
-                    datetime, countLove, isLoved, singlePostDocumentRes);
+                    datetime, countLove, isLoved, isWritten, singlePostDocumentRes);
 
             posts.add(singlePostRes);
         }
@@ -233,7 +236,7 @@ public class PostService {
 
     // 특정 post 조회
     @Transactional
-    public SinglePostRes getPost(long userId, long postId) {
+    public SinglePostRes getPost(User user, long postId) {
         // countLove 칼럼 갱신
         postRepository.updateCountLove(postId);
 
@@ -247,7 +250,10 @@ public class PostService {
         }
         
         // 로그인 유저의 post love 정보 받아오기
+        Long userId = user.getUserId();
         boolean isLoved = postLoveService.checkPostLoveByUser(postId, userId);
+        // 로그인 유저가 게시물의 작성자인지 확인하기
+        boolean isWritten = post.isWriter(user);
 
         Long filteredPostId = post.getPostId();
         String writer = post.getWriter().getNickname();
@@ -256,26 +262,26 @@ public class PostService {
         int countLove = post.getCountLove();
 
         return toSinglePostRes(filteredPostId, writer, profileImg,
-                datetime, countLove, isLoved, singlePostDocumentRes);
+                datetime, countLove, isLoved, isWritten, singlePostDocumentRes);
     }
 
     // 특정 일 최신 post 조회
     @Transactional(readOnly = true)
-    public List<SinglePostRes> getPostsOfDate(long userId, long familyId, int year, int month, int day) {
+    public List<SinglePostRes> getPostsOfDate(User user, long familyId, int year, int month, int day) {
         LocalDate date = LocalDate.of(year, month, day);
         LocalTime dummy = LocalTime.MIDNIGHT; // LocalDateTime 변수 생성을 위한 dummy 값
 
         LocalDateTime dateTime = LocalDateTime.of(date, dummy);
         Pageable pageable = PageRequest.of(0, POST_PAGES);
 
-        List<SinglePostRes> posts = getCombinedPostsByDate(familyId, dateTime, pageable);
+        List<SinglePostRes> posts = getCombinedPostsByDate(user, familyId, dateTime, pageable);
 
         return posts;
     }
 
     // 특정 일 postId 이후 post 조회
     @Transactional(readOnly = true)
-    public List<SinglePostRes> getPostsOfDate(long userId, long familyId, int year, int month, int day, long postId) {
+    public List<SinglePostRes> getPostsOfDate(User user, long familyId, int year, int month, int day, long postId) {
         LocalDate date = LocalDate.of(year, month, day);
         LocalTime dummy = LocalTime.MIDNIGHT; // LocalDateTime 변수 생성을 위한 dummy 값
 
@@ -292,6 +298,7 @@ public class PostService {
         for(Post p: filteredPosts){
             SinglePostDocumentRes singlePostDocumentRes = postDocumentRepository.findByEntityId(p.getPostId());
             boolean isLoved = postLoveService.checkPostLoveByUser(p.getPostId(), p.getWriter().getUserId());
+            boolean isWritten = p.isWriter(user);
 
             Long filteredPostId = p.getPostId();
             String writer = p.getWriter().getNickname();
@@ -300,7 +307,7 @@ public class PostService {
             int countLove = p.getCountLove();
 
             SinglePostRes singlePostRes = toSinglePostRes(filteredPostId, writer, profileImg,
-                    datetime, countLove, isLoved, singlePostDocumentRes);
+                    datetime, countLove, isLoved, isWritten, singlePostDocumentRes);
 
             posts.add(singlePostRes);
         }
@@ -335,14 +342,15 @@ public class PostService {
     @Transactional(readOnly = true)
     public List<AlbumRes> getAlbum (long familyId) {
         Pageable pageable = PageRequest.of(0, ALBUM_PAGES);
-
-        List<SinglePostRes> posts = getCombinedPosts(familyId, pageable);
+        List<Post> filteredPosts = postRepository.findByFamilyIdOrderByCreatedAtDesc(familyId, pageable);
 
         List<AlbumRes> albumResList = new ArrayList<>();
-        for(SinglePostRes singlePostRes : posts) {
+        for(Post p : filteredPosts) {
+            SinglePostDocumentRes singlePostDocumentRes = postDocumentRepository.findByEntityId(p.getPostId());
+
             AlbumRes albumRes = AlbumRes.builder()
-                    .postId(singlePostRes.getPostId())
-                    .img1(singlePostRes.getImgs().get(0))
+                    .postId(p.getPostId())
+                    .img1(singlePostDocumentRes.getUrls().get(0))
                     .build();
 
             albumResList.add(albumRes);
@@ -390,7 +398,7 @@ public class PostService {
      * @return List<SinglePostRes>
      */
     @Transactional(readOnly = true)
-    private List<SinglePostRes> getCombinedPosts(long familyId, Pageable pageable) {
+    private List<SinglePostRes> getCombinedPosts(User user, long familyId, Pageable pageable) {
         // 1. familyId에 따라서 post 목록 받아오기
         List<Post> filteredPosts = postRepository.findByFamilyIdOrderByCreatedAtDesc(familyId, pageable);
 
@@ -404,6 +412,8 @@ public class PostService {
             SinglePostDocumentRes singlePostDocumentRes = postDocumentRepository.findByEntityId(p.getPostId());
             // 3. 로그인 유저의 post love 정보 받아오기
             boolean isLoved = postLoveService.checkPostLoveByUser(p.getPostId(), p.getWriter().getUserId());
+            // 4. 로그인 유저가 게시물의 작성자인지 확인하기
+            boolean isWritten = p.isWriter(user);
 
             Long filteredPostId = p.getPostId();
             String writer = p.getWriter().getNickname();
@@ -413,7 +423,7 @@ public class PostService {
 
             // 4. 반환된 SinglePostRes 객체 목록 생성
             SinglePostRes singlePostRes = toSinglePostRes(filteredPostId, writer, profileImg,
-                    datetime, countLove, isLoved, singlePostDocumentRes);
+                    datetime, countLove, isLoved, isWritten, singlePostDocumentRes);
 
             posts.add(singlePostRes);
         }
@@ -429,13 +439,14 @@ public class PostService {
      * @return List<SinglePostRes>
      */
     @Transactional(readOnly = true)
-    private List<SinglePostRes> getCombinedPostsByDate(long familyId, LocalDateTime dateTime, Pageable pageable) {
+    private List<SinglePostRes> getCombinedPostsByDate(User user, long familyId, LocalDateTime dateTime, Pageable pageable) {
         List<Post> filteredPosts = postRepository.findByFamilyIdAndCreatedAtDesc(familyId, dateTime, pageable);
 
         List<SinglePostRes> posts = new ArrayList<>();
         for(Post p: filteredPosts){
             SinglePostDocumentRes singlePostDocumentRes = postDocumentRepository.findByEntityId(p.getPostId());
             boolean isLoved = postLoveService.checkPostLoveByUser(p.getPostId(), p.getWriter().getUserId());
+            boolean isWritten = p.isWriter(user);
 
             Long filteredPostId = p.getPostId();
             String writer = p.getWriter().getNickname();
@@ -444,7 +455,7 @@ public class PostService {
             int countLove = p.getCountLove();
 
             SinglePostRes singlePostRes = toSinglePostRes(filteredPostId, writer, profileImg,
-                    datetime, countLove, isLoved, singlePostDocumentRes);
+                    datetime, countLove, isLoved, isWritten, singlePostDocumentRes);
 
             posts.add(singlePostRes);
         }
@@ -458,8 +469,8 @@ public class PostService {
      * @return SinglePostRes
      */
     private static SinglePostRes toSinglePostRes(long postId, String writer, String profileImg,
-                                                  LocalDateTime dateTime, int countLove, boolean isLoved,
-                                                  SinglePostDocumentRes singlePostDocumentRes) {
+                                                 LocalDateTime dateTime, int countLove, boolean isLoved,
+                                                 boolean isWritten, SinglePostDocumentRes singlePostDocumentRes) {
 
         return SinglePostRes.builder()
                 .postId(postId)
@@ -470,6 +481,7 @@ public class PostService {
                 .createdAt(dateTime.toLocalDate())
                 .countLove(countLove)
                 .loved(isLoved)
+                .written(isWritten)
                 .build();
     }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/Post.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/Post.java
@@ -63,4 +63,11 @@ public class Post extends BaseEntity {
     public void updateStatus(Status status) {
         this.status = status;
     }
+
+    /**
+     * 게시물 조회 API 관련 메소드
+     */
+    public boolean isWriter(User user) {
+        return user.equals(this.writer);
+    }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/model/SinglePostRes.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/model/SinglePostRes.java
@@ -37,7 +37,8 @@ public class SinglePostRes {
     private int countLove;
     @Schema(description = "나의 좋아요 여부", example = "true or false")
     private Boolean loved;
-
+    @Schema(description = "본인의 게시물 여부", example = "true or false")
+    private Boolean written;
 
     public SinglePostRes(Long postId, String writer, String profileImg, String content, String imgs, LocalDateTime createdAt, int countLove, BaseEntity.Status status) {
         this.postId = postId;
@@ -48,5 +49,6 @@ public class SinglePostRes {
         this.createdAt = createdAt.toLocalDate();
         this.countLove = countLove;
         this.loved = status == BaseEntity.Status.ACTIVE;
+        this.written = false;
     }
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [X] 신규 기능 추가 : `SinglePostRes` 수정 (`written` 추가)
- [X] 버그 수정 : 게시글 수정과 삭제 예외 처리 분리
- [X] 리펙토링 : `createPost` 함수 리펙토링 진행 (https://github.com/familymoments/family-moments-BE/pull/140#discussion_r1555874710)
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- Post 정보 반환 시 본인의 게시물 여부를 반환하는 변수를 추가해달라는 요청 (**전체 22** 회의록 참고) 이 있어서 `written` 변수를 추가했습니다 🚀 
- 본인이 작성한 글이면 true, 아니면 false를 반환합니다
- 따라서 **게시글 작성 API 실행 후 `written`은 default로 true를 반환**합니다
- 게시글 수정과 삭제 API의 예외 메세지가 같아서 분리했습니다
- `createPost` 함수 리펙토링 진행 (https://github.com/familymoments/family-moments-BE/pull/140#discussion_r1555874710)

### 작업 후 기대 동작(스크린샷)

- 본인이 작성한 글이면 true, 아니면 false를 반환합니다
- **게시글 작성 API 실행 후 `written`은 default로 true를 반환**합니다
![image](https://github.com/familymoments/family-moments-BE/assets/55887179/393596a7-159e-4bc9-af09-a54ce67d4a65)


### PR 특이 사항

- Post 관련 API의 Response가 많이 바뀔 예정입니다 🔔 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
