### PR TITLE
fix : 로그인 및 토큰 재발급 api - cookie 제거

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -28,6 +28,7 @@ public enum BaseResponseStatus {
     INVALID_SOCIAL_TOKEN(false, HttpStatus.BAD_REQUEST.value(), "소셜 accesstoken이 유효하지 않습니다."),
     TOKEN_RESPONSE_ERROR(false, HttpStatus.NOT_FOUND.value(), "값을 불러오는데 실패하였습니다."),
     EXPIRED_JWT(false, HttpStatus.UNAUTHORIZED.value(), "만료된 토큰입니다."),
+    TOKEN_REISSUE_ERROR(false, 471, "토큰 발급을 실패했습니다."),
 
     // users
     USERS_EMPTY_USER_ID(false, HttpStatus.BAD_REQUEST.value(), "아이디를 입력해주세요."),

--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -24,6 +24,7 @@ public enum BaseResponseStatus {
     INVALID_JWT(false, 461, "Access Token의 기한이 만료되었습니다. 재발급 API를 호출해주세요"),
     INVALID_USER_JWT(false,HttpStatus.FORBIDDEN.value(),"권한이 없는 유저의 접근입니다."),
     INVALID_USER_TYPE(false, HttpStatus.BAD_REQUEST.value(), "UserType을 올바르게 입력해주세요."),
+    INVALID_REPORT_REASON(false, HttpStatus.BAD_REQUEST.value(), "유효하지 않은 게시글 신고 이유입니다."),
     INVALID_SOCIAL_TOKEN(false, HttpStatus.BAD_REQUEST.value(), "소셜 accesstoken이 유효하지 않습니다."),
     TOKEN_RESPONSE_ERROR(false, HttpStatus.NOT_FOUND.value(), "값을 불러오는데 실패하였습니다."),
     EXPIRED_JWT(false, HttpStatus.UNAUTHORIZED.value(), "만료된 토큰입니다."),

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentController.java
@@ -5,6 +5,7 @@ import com.spring.familymoments.config.NoAuthCheck;
 import com.spring.familymoments.domain.comment.model.GetCommentsRes;
 import com.spring.familymoments.domain.comment.model.PatchCommentReq;
 import com.spring.familymoments.domain.comment.model.PostCommentReq;
+import com.spring.familymoments.domain.post.model.ContentReportReq;
 import com.spring.familymoments.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -83,5 +84,16 @@ public class CommentController {
             @Valid @RequestBody PatchCommentReq patchCommentReq) {
         commentService.updateComment(commentId, patchCommentReq);
         return new BaseResponse<>("댓글이 수정되었습니다.");
+    }
+
+    /**
+     * 댓글 신고 API
+     * [POST] /comments/report/{commentId}
+     */
+    @PostMapping("/report/{commentId}")
+    public BaseResponse<String> reportComment(@AuthenticationPrincipal @Parameter(hidden = true) User user,
+                                              @PathVariable Long commentId, @RequestBody ContentReportReq contentReportReq) {
+        commentService.reportComment(user, commentId, contentReportReq);
+        return new BaseResponse<>("댓글을 신고했습니다.");
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentReportRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentReportRepository.java
@@ -1,0 +1,7 @@
+package com.spring.familymoments.domain.comment;
+
+import com.spring.familymoments.domain.comment.entity.CommentReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentReportRepository extends JpaRepository<CommentReport, Long>  {
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/entity/Comment.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/entity/Comment.java
@@ -38,6 +38,10 @@ public class Comment extends BaseEntity {
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
 
+    @Column(columnDefinition = "int unsigned")
+    @ColumnDefault("0")
+    private int reported;
+
     @Column(name = "countLove", columnDefinition = "int unsigned")
     @ColumnDefault("0")
     private int countLove;
@@ -55,5 +59,10 @@ public class Comment extends BaseEntity {
     public void updateContent(String content) {
         this.content = content;
     }
+
+    /**
+     * 댓글 신고 API 관련 메소드
+     */
+    public void updateReported(int reported) { this.reported = reported; }
 }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/entity/CommentReport.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/entity/CommentReport.java
@@ -1,0 +1,48 @@
+package com.spring.familymoments.domain.comment.entity;
+
+import com.spring.familymoments.domain.common.BaseEntity;
+import com.spring.familymoments.domain.post.entity.ReportReason;
+import com.spring.familymoments.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "CommentReport")
+@Getter
+@NoArgsConstructor(force = true)
+@AllArgsConstructor
+@Builder
+public class CommentReport extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "commentReportId", nullable = false, updatable = false)
+    private Long commentReportId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "commentId", nullable = false)
+    private Comment comment;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportReason reportReason;
+
+    private String details;
+
+    public static CommentReport createCommentReport(User fromUser, Comment reportedComment, ReportReason reportReason, String details) {
+        return CommentReport.builder()
+                .user(fromUser)
+                .comment(reportedComment)
+                .reportReason(reportReason)
+                .details(details)
+                .build();
+    }
+
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -18,9 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static com.spring.familymoments.config.BaseResponseStatus.*;
 
@@ -308,5 +306,17 @@ public class PostController {
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
+    }
+
+    /**
+     * 게시글 신고 API
+     * [POST] /posts/report/{postId}
+     *
+     */
+    @PostMapping("/report/{postId}")
+    public BaseResponse<String> reportPost(@AuthenticationPrincipal @Parameter(hidden = true) User user,
+                                           @PathVariable Long postId, @RequestBody ContentReportReq contentReportReq) {
+        postService.reportPost(user, postId, contentReportReq);
+        return new BaseResponse<>("게시글을 신고했습니다.");
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostReportRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostReportRepository.java
@@ -1,0 +1,7 @@
+package com.spring.familymoments.domain.post;
+
+import com.spring.familymoments.domain.post.entity.PostReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostReportRepository extends JpaRepository<PostReport, Long> {
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -7,6 +7,8 @@ import com.spring.familymoments.domain.family.FamilyRepository;
 import com.spring.familymoments.domain.family.entity.Family;
 import com.spring.familymoments.domain.post.document.PostDocument;
 import com.spring.familymoments.domain.post.entity.Post;
+import com.spring.familymoments.domain.post.entity.PostReport;
+import com.spring.familymoments.domain.post.entity.ReportReason;
 import com.spring.familymoments.domain.post.model.*;
 import com.spring.familymoments.domain.postLove.PostLoveService;
 import com.spring.familymoments.domain.user.entity.User;
@@ -30,6 +32,7 @@ import static com.spring.familymoments.config.BaseResponseStatus.*;
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+    private final PostReportRepository postReportRepository;
     private final PostDocumentRepository postDocumentRepository;
     private final PostLoveService postLoveService;
     private final AwsS3Service awsS3Service;
@@ -471,6 +474,29 @@ public class PostService {
                 .countLove(countLove)
                 .loved(isLoved)
                 .build();
+    }
+    @Transactional
+    public void reportPost(User fromUser, Long postId, ContentReportReq contentReportReq) {;
+       Post post = postRepository.findById(postId)
+               .orElseThrow(() -> new BaseException(minnie_POSTS_NON_EXISTS_POST));
+
+       //누적 횟수 3회차, INACTIVE
+       if(post.getReported() == 2) {
+           post.updateStatus(BaseEntity.Status.INACTIVE);
+       }
+
+       //신고 사유 저장
+       PostReport reportedPost = PostReport.createPostReport(
+               fromUser,
+               post,
+               ReportReason.getEnumTypeFromStringReportReason(contentReportReq.getReportReason()),
+               contentReportReq.getDetails()
+       );
+       postReportRepository.save(reportedPost);
+
+       //신고 횟수 업데이트
+       post.updateReported(post.getReported() + 1);
+       postRepository.save(post);
     }
 
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/Post.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/Post.java
@@ -63,4 +63,9 @@ public class Post extends BaseEntity {
     public void updateStatus(Status status) {
         this.status = status;
     }
+
+    /**
+     * 게시물 신고 API 관련 메소드
+     */
+    public void updateReported(int reported) { this.reported = reported; }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/PostReport.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/PostReport.java
@@ -1,0 +1,45 @@
+package com.spring.familymoments.domain.post.entity;
+
+import com.spring.familymoments.domain.common.BaseEntity;
+import com.spring.familymoments.domain.user.entity.User;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "PostReport")
+@Getter
+@NoArgsConstructor(force = true)
+@AllArgsConstructor
+@Builder
+public class PostReport extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "postReportId", nullable = false, updatable = false)
+    private Long postReportId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "postId", nullable = false)
+    private Post post;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportReason reportReason;
+
+    private String details;
+
+    public static PostReport createPostReport(User fromUser, Post reportedPost, ReportReason reportReason, String details) {
+        return PostReport.builder()
+                .user(fromUser)
+                .post(reportedPost)
+                .reportReason(reportReason)
+                .details(details)
+                .build();
+    }
+
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/ReportReason.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/ReportReason.java
@@ -1,0 +1,31 @@
+package com.spring.familymoments.domain.post.entity;
+
+import com.spring.familymoments.config.BaseException;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+import static com.spring.familymoments.config.BaseResponseStatus.INVALID_REPORT_REASON;
+
+@RequiredArgsConstructor
+@Getter
+public enum ReportReason {
+    COMMERCIAL_PROMOTION("영리목적/홍보성"),
+    COPYRIGHT("저작권 침해"),
+    OBSCENITY("음란성/선정성"),
+    ABUSE("욕설/인신공격"),
+    SPAM("같은내용 반복게시"),
+    PERSONAL_INFORMATION_EXPOSURE("개인정보노출"),
+    OTHER("기타");
+
+    private final String stringReportReason;
+
+    public static ReportReason getEnumTypeFromStringReportReason(String stringReportReason) {
+        return Arrays.stream(values())
+                .filter(reportReason -> reportReason.stringReportReason.equals(stringReportReason))
+                .findFirst()
+                .orElseThrow(() -> new BaseException(INVALID_REPORT_REASON));
+    }
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/model/ContentReportReq.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/model/ContentReportReq.java
@@ -1,0 +1,19 @@
+package com.spring.familymoments.domain.post.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "게시물 신고 Request")
+public class ContentReportReq {
+    @Schema(description = "신고 사유", example = "영리목적/홍보성")
+    private String reportReason;
+    @Schema(description = "자세한 신고 사유", example = "부가설명")
+    private String details;
+}

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthController.java
@@ -2,7 +2,6 @@ package com.spring.familymoments.domain.user;
 
 import com.spring.familymoments.config.BaseResponse;
 import com.spring.familymoments.config.NoAuthCheck;
-import com.spring.familymoments.config.secret.jwt.JwtSecret;
 import com.spring.familymoments.config.secret.jwt.model.TokenDto;
 import com.spring.familymoments.domain.fcm.FCMService;
 import com.spring.familymoments.domain.user.entity.User;
@@ -19,46 +18,38 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import static com.spring.familymoments.config.BaseResponseStatus.SUCCESS;
 
-import static com.spring.familymoments.config.BaseResponseStatus.FIND_FAIL_FCMTOKEN;
+import javax.validation.Valid;
+
+import static com.spring.familymoments.config.BaseResponseStatus.*;
 
 
 @Controller
 @RequiredArgsConstructor
 @Tag(name = "User-Auth", description = "인증토큰 API Document")
 public class AuthController {
-    private final long COOKIE_EXPIRATION = JwtSecret.COOKIE_EXPIRATION_TIME;
     private final AuthService authService;
     private final FCMService fcmService;
     /**
      * 로그인 API -> token 발급
      * [POST] /users/log-in
      * return 200
-     *        [header] Cookie : "refresh-token=e~~~" (refresh-token)
-     *                 X-AUTH-TOKEN : e~~~ (access-token)
+     *        [header]
+     *        REFRESH-TOKEN : e~~~ (refresh-token)
+     *        X-AUTH-TOKEN : e~~~ (access-token)
      */
     @PostMapping(value = "/users/log-in", produces = MediaType.APPLICATION_JSON_VALUE)
-    @Operation(summary = "로그인", description = "accessToken을 header로 refreshToken을 cookie로 발급하면서, 로그인합니다.")
+    @Operation(summary = "로그인", description = "accessToken과 refreshToken을 header로 발급하면서 로그인합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PostLoginRes.class)))
             //@ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
-    public ResponseEntity<?> login(@RequestHeader(value = "FCM-Token", required = false) String fcmToken, @RequestBody PostLoginReq postLoginReq) {
+    public ResponseEntity<?> login(@RequestHeader(value = "FCM-Token", required = false) String fcmToken, @Valid @RequestBody PostLoginReq postLoginReq) {
         //User 등록 및 Refresh Token 저장
         TokenDto tokenDto = authService.login(postLoginReq);
-
-        //RefreshToken 쿠키에 저장
-        HttpCookie httpCookie = ResponseCookie.from("refresh-token", tokenDto.getRefreshToken())
-                .maxAge(COOKIE_EXPIRATION)
-                .httpOnly(true)
-                .secure(true)
-                .build();
-
         //가입된 familyId 값 넘기기 -- 임시
         PostLoginRes postLoginRes = authService.login_familyId(postLoginReq.getId());
 
@@ -69,9 +60,9 @@ public class AuthController {
         fcmService.saveToken(postLoginReq.getId(), fcmToken);
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, httpCookie.toString())
                 .header("X-AUTH-TOKEN", tokenDto.getAccessToken())
-                .body(new BaseResponse<PostLoginRes>(postLoginRes)); //.build();
+                .header("REFRESH-TOKEN", tokenDto.getRefreshToken())
+                .body(new BaseResponse<PostLoginRes>(postLoginRes));
     }
 
     /**
@@ -88,9 +79,11 @@ public class AuthController {
     })
     public ResponseEntity<?> validate(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken) {
         if (!authService.validate(requestAccessToken)) {
-            return ResponseEntity.status(HttpStatus.OK).build(); // 재발급 필요X
+            return ResponseEntity.ok()
+                    .body(new BaseResponse<String>("토큰이 정상입니다.")); //재발급 필요X
         } else {
-            return ResponseEntity.status(461).build(); // 재발급 필요
+            return ResponseEntity.status(461)
+                    .body(new BaseResponse<>(INVALID_JWT)); // 재발급 필요
         }
     }
 
@@ -98,10 +91,10 @@ public class AuthController {
      * 토큰 재발급 API
      * [POST] /users/reissue
      * return 200
-     *      [header] Cookie : "refresh-token=e~~~" (refresh-token)
-     *               X-AUTH-TOKEN : e~~~ (access-token)
+     *      [header]
+     *      *        REFRESH-TOKEN : e~~~ (refresh-token)
+     *      *        X-AUTH-TOKEN : e~~~ (access-token)
      * return 471
-     *      [header] Cookie : "refresh-token=(empty)" (refresh-token)
      */
     @NoAuthCheck
     @PostMapping(value = "/users/reissue", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -110,36 +103,23 @@ public class AuthController {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "471", description = "재로그인 해야합니다.")
     })
-    public ResponseEntity<?> reissue(@CookieValue(name = "refresh-token") String requestRefreshToken,
+    public ResponseEntity<?> reissue(@RequestHeader("REFRESH-TOKEN") String requestRefreshToken,
                                      @RequestHeader("X-AUTH-TOKEN") String requestAccessToken) {
         TokenDto reissuedTokenDto = authService.reissue(requestAccessToken, requestRefreshToken);
 
         if(reissuedTokenDto == null) {//Refresh Token 탈취 가능성
-            ResponseCookie responseCookie = ResponseCookie.from("refresh-token", "")
-                    .maxAge(0)
-                    .path("/")
-                    .build(); //쿠키 삭제 후 재로그인 유도
-            return ResponseEntity
-                    .status(471)
-                    .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
-                    .build();
+            return ResponseEntity.status(471)
+                    .body(new BaseResponse<String>(TOKEN_REISSUE_ERROR));
         }
-        //토큰 재발급 성공
-        ResponseCookie responseCookie = ResponseCookie.from("refresh-token", reissuedTokenDto.getRefreshToken())
-                .maxAge(COOKIE_EXPIRATION)
-                .httpOnly(true)
-                .secure(true)
-                .build();
         return ResponseEntity.status(HttpStatus.OK)
-                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .header("REFRESH-TOKEN", reissuedTokenDto.getRefreshToken())
                 .header("X-AUTH-TOKEN", reissuedTokenDto.getAccessToken())
-                .build();
+                .body(new BaseResponse<>("토큰 발급을 성공했습니다."));
     }
     /**
      * 로그아웃 API
      * [POST] /users/log-out
      * return 200
-     *       [header] Cookie : "refresh-token=(empty)" (refresh-token)
      */
     @PostMapping(value = "/users/log-out", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "로그아웃", description = "쿠키의 내용 지우면서 로그아웃합니다.")
@@ -148,13 +128,7 @@ public class AuthController {
                                     @AuthenticationPrincipal @Parameter(hidden = true) User user) {
         authService.logout(requestAccessToken);
         fcmService.deleteToken(user.getId());     // FCM Token 삭제
-
-        ResponseCookie responseCookie = ResponseCookie.from("refresh-token", "")
-                .maxAge(0)
-                .path("/")
-                .build();
         return ResponseEntity.status(HttpStatus.OK)
-                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
                 .body(new BaseResponse<>(SUCCESS));
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -477,4 +477,15 @@ public class UserController {
         fcmService.deleteToken(user.getId());     // FCM Token 삭제
         return new BaseResponse<>("계정을 삭제했습니다.");
     }
+
+    /**
+     * 유저 신고 API
+     * [POST] /users/report
+     */
+    @PostMapping("/users/report/{userId}")
+    public BaseResponse<String> reportUser(@PathVariable Long userId) {
+        userService.reportUser(userId);
+        return new BaseResponse<>("유저를 신고했습니다.");
+    }
+
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -344,4 +344,18 @@ public class UserService {
         //socialUserService.deleteSocialUserWithRedisProcess(user);
     }
 
+    public void reportUser(Long toUserId) {
+        User toUser = userRepository.findById(toUserId)
+                .orElseThrow(() -> new BaseException(FIND_FAIL_USERNAME));
+
+        //누적 횟수 3회차, INACTIVE
+        if(toUser.getReported() == 2) {
+            toUser.updateStatus(User.Status.INACTIVE);
+        }
+
+        //신고 횟수 업데이트
+        toUser.updateReported(toUser.getReported() + 1);
+        userRepository.save(toUser);
+    }
+
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/entity/User.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/entity/User.java
@@ -156,4 +156,12 @@ public class User extends BaseTime implements UserDetails {
     public void updateStatus(Status status) {
         this.status = status;
     }
+
+    /**
+     * 회원 신고 API 관련 메서ㅗ드
+     */
+    public void updateReported(int reported) {
+        this.reported = reported;
+    }
+
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostLoginReq.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostLoginReq.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 @Schema(description = "로그인 관련 Request")
 public class PostLoginReq {
-    @NotBlank(message = "id를 입력하세요.")
+    @NotBlank(message = "아이디를 입력하세요.")
     @Schema(description = "아이디", example = "familya5")
     private String id;
     @NotBlank(message = "비밀번호를 입력하세요.")


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 로그인 및 토큰 재발급 api - cookie 제거
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 웹이 아닌 안드로이드에서는 쿠키를 사용할 수 없습니다 !

### 작업 내역

- 기존에 refreshtoken을 cookie로 전달하고 있었는데, header로 보내는 것으로 수정했습니다.
- @ valid 추가했습니다.

### 작업 후 기대 동작(스크린샷)
- 토큰 재발급 api (200OK)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/ff9db32d-beb1-4d7d-9b60-4fb5e243bc27)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/572a0abc-536a-4db1-bdae-6ad7ae7c46a9)
- 토큰 재발급 api (471)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/195d4a1f-5601-4113-8bf4-c39393b08ea3)
