### PR TITLE
fix: 로그인과 토큰 재발급 api 쿠키 제거

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -27,6 +27,7 @@ public enum BaseResponseStatus {
     INVALID_SOCIAL_TOKEN(false, HttpStatus.BAD_REQUEST.value(), "소셜 accesstoken이 유효하지 않습니다."),
     TOKEN_RESPONSE_ERROR(false, HttpStatus.NOT_FOUND.value(), "값을 불러오는데 실패하였습니다."),
     EXPIRED_JWT(false, HttpStatus.UNAUTHORIZED.value(), "만료된 토큰입니다."),
+    TOKEN_REISSUE_ERROR(false, 471, "토큰 발급을 실패했습니다."),
 
     // users
     USERS_EMPTY_USER_ID(false, HttpStatus.BAD_REQUEST.value(), "아이디를 입력해주세요."),

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthController.java
@@ -2,7 +2,6 @@ package com.spring.familymoments.domain.user;
 
 import com.spring.familymoments.config.BaseResponse;
 import com.spring.familymoments.config.NoAuthCheck;
-import com.spring.familymoments.config.secret.jwt.JwtSecret;
 import com.spring.familymoments.config.secret.jwt.model.TokenDto;
 import com.spring.familymoments.domain.fcm.FCMService;
 import com.spring.familymoments.domain.user.entity.User;
@@ -19,46 +18,38 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import static com.spring.familymoments.config.BaseResponseStatus.SUCCESS;
 
-import static com.spring.familymoments.config.BaseResponseStatus.FIND_FAIL_FCMTOKEN;
+import javax.validation.Valid;
+
+import static com.spring.familymoments.config.BaseResponseStatus.*;
 
 
 @Controller
 @RequiredArgsConstructor
 @Tag(name = "User-Auth", description = "인증토큰 API Document")
 public class AuthController {
-    private final long COOKIE_EXPIRATION = JwtSecret.COOKIE_EXPIRATION_TIME;
     private final AuthService authService;
     private final FCMService fcmService;
     /**
      * 로그인 API -> token 발급
      * [POST] /users/log-in
      * return 200
-     *        [header] Cookie : "refresh-token=e~~~" (refresh-token)
-     *                 X-AUTH-TOKEN : e~~~ (access-token)
+     *        [header]
+     *        REFRESH-TOKEN : e~~~ (refresh-token)
+     *        X-AUTH-TOKEN : e~~~ (access-token)
      */
     @PostMapping(value = "/users/log-in", produces = MediaType.APPLICATION_JSON_VALUE)
-    @Operation(summary = "로그인", description = "accessToken을 header로 refreshToken을 cookie로 발급하면서, 로그인합니다.")
+    @Operation(summary = "로그인", description = "accessToken과 refreshToken을 header로 발급하면서 로그인합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PostLoginRes.class)))
             //@ApiResponse(responseCode = "404", description = "NOT FOUND", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
-    public ResponseEntity<?> login(@RequestHeader(value = "FCM-Token", required = false) String fcmToken, @RequestBody PostLoginReq postLoginReq) {
+    public ResponseEntity<?> login(@RequestHeader(value = "FCM-Token", required = false) String fcmToken, @Valid @RequestBody PostLoginReq postLoginReq) {
         //User 등록 및 Refresh Token 저장
         TokenDto tokenDto = authService.login(postLoginReq);
-
-        //RefreshToken 쿠키에 저장
-        HttpCookie httpCookie = ResponseCookie.from("refresh-token", tokenDto.getRefreshToken())
-                .maxAge(COOKIE_EXPIRATION)
-                .httpOnly(true)
-                .secure(true)
-                .build();
-
         //가입된 familyId 값 넘기기 -- 임시
         PostLoginRes postLoginRes = authService.login_familyId(postLoginReq.getId());
 
@@ -69,9 +60,9 @@ public class AuthController {
         fcmService.saveToken(postLoginReq.getId(), fcmToken);
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, httpCookie.toString())
                 .header("X-AUTH-TOKEN", tokenDto.getAccessToken())
-                .body(new BaseResponse<PostLoginRes>(postLoginRes)); //.build();
+                .header("REFRESH-TOKEN", tokenDto.getRefreshToken())
+                .body(new BaseResponse<PostLoginRes>(postLoginRes));
     }
 
     /**
@@ -88,9 +79,11 @@ public class AuthController {
     })
     public ResponseEntity<?> validate(@RequestHeader("X-AUTH-TOKEN") String requestAccessToken) {
         if (!authService.validate(requestAccessToken)) {
-            return ResponseEntity.status(HttpStatus.OK).build(); // 재발급 필요X
+            return ResponseEntity.ok()
+                    .body(new BaseResponse<String>("토큰이 정상입니다.")); //재발급 필요X
         } else {
-            return ResponseEntity.status(461).build(); // 재발급 필요
+            return ResponseEntity.status(461)
+                    .body(new BaseResponse<>(INVALID_JWT)); // 재발급 필요
         }
     }
 
@@ -98,10 +91,10 @@ public class AuthController {
      * 토큰 재발급 API
      * [POST] /users/reissue
      * return 200
-     *      [header] Cookie : "refresh-token=e~~~" (refresh-token)
-     *               X-AUTH-TOKEN : e~~~ (access-token)
+     *      [header]
+     *      *        REFRESH-TOKEN : e~~~ (refresh-token)
+     *      *        X-AUTH-TOKEN : e~~~ (access-token)
      * return 471
-     *      [header] Cookie : "refresh-token=(empty)" (refresh-token)
      */
     @NoAuthCheck
     @PostMapping(value = "/users/reissue", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -110,36 +103,23 @@ public class AuthController {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "471", description = "재로그인 해야합니다.")
     })
-    public ResponseEntity<?> reissue(@CookieValue(name = "refresh-token") String requestRefreshToken,
+    public ResponseEntity<?> reissue(@RequestHeader("REFRESH-TOKEN") String requestRefreshToken,
                                      @RequestHeader("X-AUTH-TOKEN") String requestAccessToken) {
         TokenDto reissuedTokenDto = authService.reissue(requestAccessToken, requestRefreshToken);
 
         if(reissuedTokenDto == null) {//Refresh Token 탈취 가능성
-            ResponseCookie responseCookie = ResponseCookie.from("refresh-token", "")
-                    .maxAge(0)
-                    .path("/")
-                    .build(); //쿠키 삭제 후 재로그인 유도
-            return ResponseEntity
-                    .status(471)
-                    .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
-                    .build();
+            return ResponseEntity.status(471)
+                    .body(new BaseResponse<String>(TOKEN_REISSUE_ERROR));
         }
-        //토큰 재발급 성공
-        ResponseCookie responseCookie = ResponseCookie.from("refresh-token", reissuedTokenDto.getRefreshToken())
-                .maxAge(COOKIE_EXPIRATION)
-                .httpOnly(true)
-                .secure(true)
-                .build();
         return ResponseEntity.status(HttpStatus.OK)
-                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .header("REFRESH-TOKEN", reissuedTokenDto.getRefreshToken())
                 .header("X-AUTH-TOKEN", reissuedTokenDto.getAccessToken())
-                .build();
+                .body(new BaseResponse<>("토큰 발급을 성공했습니다."));
     }
     /**
      * 로그아웃 API
      * [POST] /users/log-out
      * return 200
-     *       [header] Cookie : "refresh-token=(empty)" (refresh-token)
      */
     @PostMapping(value = "/users/log-out", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "로그아웃", description = "쿠키의 내용 지우면서 로그아웃합니다.")
@@ -148,13 +128,7 @@ public class AuthController {
                                     @AuthenticationPrincipal @Parameter(hidden = true) User user) {
         authService.logout(requestAccessToken);
         fcmService.deleteToken(user.getId());     // FCM Token 삭제
-
-        ResponseCookie responseCookie = ResponseCookie.from("refresh-token", "")
-                .maxAge(0)
-                .path("/")
-                .build();
         return ResponseEntity.status(HttpStatus.OK)
-                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
                 .body(new BaseResponse<>(SUCCESS));
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostLoginReq.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostLoginReq.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 @Schema(description = "로그인 관련 Request")
 public class PostLoginReq {
-    @NotBlank(message = "id를 입력하세요.")
+    @NotBlank(message = "아이디를 입력하세요.")
     @Schema(description = "아이디", example = "familya5")
     private String id;
     @NotBlank(message = "비밀번호를 입력하세요.")


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 로그인 및 토큰 재발급 api - cookie 제거
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 웹이 아닌 안드로이드에서는 쿠키를 사용할 수 없습니다 !

### 작업 내역

- 기존에 refreshtoken을 cookie로 전달하고 있었는데, header로 보내는 것으로 수정했습니다.
- @ valid 추가했습니다.

### 작업 후 기대 동작(스크린샷)
- 토큰 재발급 api (200OK)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/ff9db32d-beb1-4d7d-9b60-4fb5e243bc27)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/572a0abc-536a-4db1-bdae-6ad7ae7c46a9)
- 토큰 재발급 api (471)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/195d4a1f-5601-4113-8bf4-c39393b08ea3)
