### PR TITLE
fix : 소셜 snsId 제거, 일반 회원가입 response string으로

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/GoogleLoginServiceImpl.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/GoogleLoginServiceImpl.java
@@ -57,7 +57,6 @@ public class GoogleLoginServiceImpl implements SocialLoginService {
         GoogleLoginResponse googleLoginResponse = response.getBody();
 
         return SocialUserResponse.builder()
-                .snsId(googleLoginResponse.getId())
                 .name(googleLoginResponse.getName())
                 .picture(googleLoginResponse.getPicture())
                 .email(googleLoginResponse.getEmail())

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/KakaoLoginServiceImpl.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/KakaoLoginServiceImpl.java
@@ -70,7 +70,6 @@ public class KakaoLoginServiceImpl implements SocialLoginService {
         KaKaoLoginResponse.KakaoLoginData.KakaoProfile kakaoProfile = kakaoLoginData.getProfile();
 
         return SocialUserResponse.builder()
-                .snsId(kaKaoLoginResponse.getId())
                 .name(kakaoLoginData.getName())
                 .email(kakaoLoginData.getEmail())
                 .birthyear(kakaoLoginData.getBirthyear())

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/NaverLoginServiceImpl.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/NaverLoginServiceImpl.java
@@ -67,7 +67,6 @@ public class NaverLoginServiceImpl implements SocialLoginService {
         NaverLoginResponse.Response naverUserInfo = naverLoginResponse.getResponse();
 
         return SocialUserResponse.builder()
-                .snsId(naverUserInfo.getId())
                 .name(naverUserInfo.getName())
                 .email(naverUserInfo.getEmail())
                 .birthyear(naverUserInfo.getBirthyear())

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserController.java
@@ -29,9 +29,10 @@ public class SocialUserController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK")
     })
-    public ResponseEntity<BaseResponse<SocialLoginResponse>> doSocialSdkLogin(@Parameter(description = "소셜 accesstoken") @RequestHeader("SOCIAL-TOKEN") String socialToken,
+    public ResponseEntity<BaseResponse<SocialLoginResponse>> doSocialSdkLogin(@RequestHeader(value = "FCM-Token", required = false) String fcmToken,
+                                                                              @Parameter(description = "소셜 accesstoken") @RequestHeader("SOCIAL-TOKEN") String socialToken,
                                                                               @Parameter(description = "소셜 종류") @RequestBody SocialLoginSdkRequest socialLoginSdkRequest) {
-        SocialLoginDto socialLoginResponse = socialUserService.createSocialSdkUser(socialToken, socialLoginSdkRequest);
+        SocialLoginDto socialLoginResponse = socialUserService.createSocialSdkUser(socialToken, fcmToken, socialLoginSdkRequest);
 
         TokenDto tokenDto = socialLoginResponse.getTokenDto();
         String accessToken = (tokenDto != null) ? tokenDto.getAccessToken() : null;
@@ -45,7 +46,6 @@ public class SocialUserController {
                 .body(
                         new BaseResponse<>(SocialLoginResponse.of(
                                 isExisted,
-                                isExisted ? null : socialLoginResponse.getSnsId(),
                                 isExisted ? null : socialLoginResponse.getName(),
                                 isExisted ? null : socialLoginResponse.getEmail(),
                                 isExisted ? null : socialLoginResponse.getStrBirthDate(),
@@ -76,5 +76,6 @@ public class SocialUserController {
                         socialJoinDto.getFamilyId()))
                 );
     }
+
 
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserController.java
@@ -50,7 +50,9 @@ public class SocialUserController {
                                 isExisted ? null : socialLoginResponse.getEmail(),
                                 isExisted ? null : socialLoginResponse.getStrBirthDate(),
                                 isExisted ? null : socialLoginResponse.getNickname(),
-                                isExisted ? null : socialLoginResponse.getPicture()))
+                                isExisted ? null : socialLoginResponse.getPicture(),
+                                isExisted ? socialLoginResponse.getFamilyId() : null)
+                        )
                 );
     }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserRepository.java
@@ -16,9 +16,5 @@ public interface SocialUserRepository extends JpaRepository<SocialInfo, Long> {
     @Query("SELECT u FROM User u LEFT JOIN SocialInfo si ON u = si.user WHERE u.email = :email AND si.type = :userType")
     Optional<User> findUserByEmailAndUserType(@Param("email") String email, @Param("userType") UserType userType);
 
-    //sdk version
-    @Query("SELECT u FROM User u LEFT JOIN SocialInfo si ON u= si.user WHERE u.email = :email AND si.snsUserId = :snsId")
-    User findUserByEmailAndSnsId(@Param("email") String email, @Param("snsId") String snsId);
-
     List<SocialInfo> findSocialInfoByUser(User user);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserService.java
@@ -81,6 +81,7 @@ public class SocialUserService {
     public SocialLoginDto createSocialSdkUser(String socialToken, String fcmToken, SocialLoginSdkRequest socialLoginSdkRequest) {
         try {
             boolean isExisted = false;
+            Long familyId = null;
             //userType
             String strUserType = socialLoginSdkRequest.getUserType();
             UserType enumUserType = UserType.getEnumUserTypeFromStringUserType(strUserType);
@@ -98,6 +99,8 @@ public class SocialUserService {
             if(existedU != null && existedU.isPresent()) {
                 isExisted = true;
                 tokenDto = setAuthenticationInSocial(existedU.get());
+                //familyId 반환
+                familyId = authService.login_familyId(existedU.get().getId()).getFamilyId();
             }
 
             //신규회원의 유저정보 중 Naver와 Kakao의 bithday + birthyear -> birthdate 형식 반영
@@ -128,7 +131,8 @@ public class SocialUserService {
                     socialUserResponse.getEmail(),
                     strBirthDate,
                     socialUserResponse.getNickname(),
-                    socialUserResponse.getPicture()
+                    socialUserResponse.getPicture(),
+                    familyId
             );
 
         } catch (FeignException e) {

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/entity/SocialInfo.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/entity/SocialInfo.java
@@ -4,6 +4,7 @@ import com.spring.familymoments.domain.common.BaseEntity;
 import com.spring.familymoments.domain.socialInfo.UserType;
 import com.spring.familymoments.domain.user.entity.User;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
@@ -30,8 +31,11 @@ public class SocialInfo extends BaseEntity {
     private User user;
     @Column(name = "type", nullable = false, length = 10)
     private UserType type = UserType.NORMAL;
+
+    @ColumnDefault("temp")
+    @Builder.Default()
     @Column(columnDefinition = "TEXT", nullable = false)
-    private String snsUserId;
+    private String snsUserId = "temp";
 
     /**
      * 회원 탈퇴 API 관련 메소드

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginDto.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginDto.java
@@ -11,7 +11,6 @@ import lombok.*;
 public class SocialLoginDto {
     private Boolean isExisted;
     private TokenDto tokenDto;
-    private String snsId;
     private String name;
     private String email;
     private String strBirthDate;
@@ -19,13 +18,12 @@ public class SocialLoginDto {
     private String picture;
 
     public static SocialLoginDto of(Boolean isExisted, TokenDto tokenDto,
-                                    String snsId, String name, String email, String strBirthDate,
+                                    String name, String email, String strBirthDate,
                                     String nickname, String picture) {
 
         return SocialLoginDto.builder()
                 .isExisted(isExisted)
                 .tokenDto(tokenDto)
-                .snsId(snsId)
                 .name(name)
                 .email(email)
                 .strBirthDate(strBirthDate)

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginDto.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginDto.java
@@ -16,10 +16,12 @@ public class SocialLoginDto {
     private String strBirthDate;
     private String nickname;
     private String picture;
+    private Long familyId;
 
     public static SocialLoginDto of(Boolean isExisted, TokenDto tokenDto,
                                     String name, String email, String strBirthDate,
-                                    String nickname, String picture) {
+                                    String nickname, String picture,
+                                    Long familyId) {
 
         return SocialLoginDto.builder()
                 .isExisted(isExisted)
@@ -29,6 +31,7 @@ public class SocialLoginDto {
                 .strBirthDate(strBirthDate)
                 .nickname(nickname)
                 .picture(picture)
+                .familyId(familyId)
                 .build();
     }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginResponse.java
@@ -23,10 +23,13 @@ public class SocialLoginResponse {
     private String nickname;
     @Schema(description = "프로필 사진", example = "[url]")
     private String picture;
+    @Schema(description = "가족 아이디", example = "null")
+    private Long familyId;
 
     public static SocialLoginResponse of(Boolean isExisted,
                                          String name, String email, String strBirthDate,
-                                         String nickname, String picture) {
+                                         String nickname, String picture,
+                                         Long familyId) {
 
         return SocialLoginResponse.builder()
                 .isExisted(isExisted)
@@ -35,6 +38,7 @@ public class SocialLoginResponse {
                 .strBirthDate(strBirthDate)
                 .nickname(nickname)
                 .picture(picture)
+                .familyId(familyId)
                 .build();
     }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialLoginResponse.java
@@ -13,8 +13,6 @@ import lombok.*;
 public class SocialLoginResponse {
     @Schema(description = "기존회원있음", example = "true")
     private Boolean isExisted;
-    @Schema(description = "소셜 고유 ID", example = "23231221421")
-    private String snsId;
     @Schema(description = "이름", example = "김영희")
     private String name;
     @Schema(description = "이메일", example = "younghee@kakao.com")
@@ -27,12 +25,11 @@ public class SocialLoginResponse {
     private String picture;
 
     public static SocialLoginResponse of(Boolean isExisted,
-                                         String snsId, String name, String email, String strBirthDate,
+                                         String name, String email, String strBirthDate,
                                          String nickname, String picture) {
 
         return SocialLoginResponse.builder()
                 .isExisted(isExisted)
-                .snsId(snsId)
                 .name(name)
                 .email(email)
                 .strBirthDate(strBirthDate)

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialUserResponse.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/SocialUserResponse.java
@@ -9,7 +9,6 @@ import lombok.*;
 @ToString
 public class SocialUserResponse {
     //리소스 서버에서 가져온 정보들
-    private String snsId; //네.카.구. 식별자
     private String name;
     private String email;
     private String birthyear;

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/UserJoinRequest.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/model/UserJoinRequest.java
@@ -24,6 +24,4 @@ public class UserJoinRequest {
     private String nickname;
     @Schema(description = "프로필 사진", example = "null(고정), 아래 profileImg에 등록 바람.")
     private String profileImg;
-    @Schema(description = "소셜 고유 ID", example = "23231221421")
-    private String snsId;
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -56,7 +56,7 @@ public class UserController {
     @PostMapping(value = "/users/sign-up",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "회원 가입", description = "회원 가입에 사용되는 API 입니다.")
-    public BaseResponse<PostUserRes> createUser(@Parameter(description = "새로운 회원의 가입 정보")
+    public BaseResponse<String> createUser(@Parameter(description = "새로운 회원의 가입 정보")
                                                     @RequestPart("newUser") PostUserReq.joinUser postUserReq,
                                                 @Parameter(description = "새로운 회원의 프로필 이미지")
                                                     @RequestPart("profileImg") MultipartFile profileImage) {
@@ -120,7 +120,7 @@ public class UserController {
 
         PostUserRes postUserRes = userService.createUser(postUserReq, profileImage);
         // log.info("[createUser]: PostUserRes 생성 완료!");
-        return new BaseResponse<>(postUserRes);
+        return new BaseResponse<>("회원가입을 성공했습니다.");
     }
 
     /**


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 소셜 : snsId 제거, fcmToken header 추가 / 일반회원가입 : response string으로
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역
- snsId 제거 되었습니다.
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/96e861c7-1a6c-4b0c-96bc-fbed9987e1ee)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/2667b673-d2b1-4e29-a640-4aab2fd4fd5e)
- request body에서도 snsId 제거 되었습니다.
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/f130a5cf-da07-47db-b0aa-d6bcf7816d48)
- fcmToken 소셜로그인에도 추가했습니다.
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/df18c418-7739-41ed-8803-ca5213a67bb4)

- 일반회원가입 response 형태를 string으로 (기존에 email 등등을 보냈었음)
![image](https://github.com/familymoments/family-moments-BE/assets/97500298/31df825b-2c8a-45b4-8174-4f68332ee276)


### PR 특이 사항

- entity에 있는 필드인 snsId를 빼려 했지만, table을 drop 후 반영해야 해서 임시로 default 만 넣어서 해결했습니다.
- 추후 socialInfo table도 빼도 될듯합니다 ! (snsId 필드도 없앴고 해서..)