### PR TITLE
fix: 본인인증 메일 발송 API 수정 (@Valid 적용)

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -44,6 +44,7 @@ public enum BaseResponseStatus {
     POST_USERS_INVALID_BIRTH(false, HttpStatus.BAD_REQUEST.value(), "생년월일 형식을 확인해주세요."),
     POST_USERS_EMPTY_NICKNAME(false, HttpStatus.BAD_REQUEST.value(), "닉네임을 입력해주세요."),
     POST_USERS_INVALID_NICKNAME(false, HttpStatus.BAD_REQUEST.value(), "닉네임 형식을 확인해주세요."),
+    EMPTY_VERIFICATION_CODE(false, HttpStatus.BAD_REQUEST.value(), "받은 인증 코드를 입력해주세요."),
     NOT_EQUAL_VERIFICATION_CODE(false, HttpStatus.BAD_REQUEST.value(), "인증 번호가 일치하지 않습니다."),
     VERIFICATION_TIME_EXPIRED(false, HttpStatus.BAD_REQUEST.value(), "인증 유효 시간이 만료되었습니다. 다시 인증을 요청해주세요."),
     FIND_FAIL_USER_NAME_EMAIL(false,HttpStatus.NOT_FOUND.value(), "이름과 이메일이 정확히 입력되었는지 확인해주세요."),

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailService.java
@@ -27,7 +27,7 @@ public class EmailService {
     private final UserRepository userRepository;
 
     private final RedisService redisService;
-    
+
     private final JavaMailSender emailSender;
 
     private String randomVerificationCode;
@@ -59,15 +59,15 @@ public class EmailService {
         String title = "Family Moments 본인 인증 번호";
         String messageContext = "";
         messageContext += "<div style = \"background-color: #F7E1E3; margin: -8px -8px 50px -8px; height: 100px; padding-top: 50px;\">\n" +
-                          "<span style = \"color: #5B6380; margin-left:50px; text-align: left; font-weight:900; font-family: Segoe Script; font-size: 25px;\">Family Moments</span>\n" +
-                          "</div>\n" +
-                          "<h1 style = \"display: flex; justify-content: flex-start; margin-left:50px; font-weight:900; font-family: Roboto; font-size:35px; margin-bottom: 80px;\">이메일 인증</h1>\n" +
-                          "<h2 style = \"display: flex; justify-content: flex-start; margin-left:50px; font-weight:900; font-family: Roboto; font-size:20px; margin-bottom: 10px;\">안녕하세요, 고객님</h2>\n" +
-                          "<p style = \"display: flex; justify-content: flex-start; margin-left:50px; font-weight:900; font-family: Roboto; margin-bottom: 60px;\">아이디 찾기/비밀번호 재설정을 위해 이메일 인증을 진행합니다.\n" +
-                          "아래 발급된 이메일 인증번호를 복사하거나 직접 입력하여 인증을 완료해주세요.</p>\n" +
-                          "<span style = \"display: flex; justify-content: flex-start; margin-left:50px; font-weight:900; font-family: Roboto; margin-bottom: 10px;\">인증번호 : " + randomVerificationCode + "</span>\n" +
-                          "<p style = \"display: flex; justify-content: flex-start; margin-left:50px; font-weight:900; font-family: Roboto; margin-bottom: 100px;\">감사합니다.</p>\n" +
-                          "<p style = \"color: #96979C; display: flex; justify-content: flex-start; margin-left:50px; font-weight:900; font-family: Roboto; font-size: 10px;\">* 귀하가 한 행동이 아니라면 이 이메일을 무시하셔도 됩니다.</p>\n";
+                "<span style = \"color: #5B6380; margin-left:50px; text-align: left; font-weight:900; font-family: Segoe Script; font-size: 25px;\">Family Moments</span>\n" +
+                "</div>\n" +
+                "<h1 style = \"display: flex; justify-content: flex-start; margin-left:50px; font-weight:900; font-family: Roboto; font-size:35px; margin-bottom: 80px;\">이메일 인증</h1>\n" +
+                "<h2 style = \"display: flex; justify-content: flex-start; margin-left:50px; font-weight:900; font-family: Roboto; font-size:20px; margin-bottom: 10px;\">안녕하세요, 고객님</h2>\n" +
+                "<p style = \"display: flex; justify-content: flex-start; margin-left:50px; font-weight:900; font-family: Roboto; margin-bottom: 60px;\">아이디 찾기/비밀번호 재설정을 위해 이메일 인증을 진행합니다.\n" +
+                "아래 발급된 이메일 인증번호를 복사하거나 직접 입력하여 인증을 완료해주세요.</p>\n" +
+                "<span style = \"display: flex; justify-content: flex-start; margin-left:50px; font-weight:900; font-family: Roboto; margin-bottom: 10px;\">인증번호 : " + randomVerificationCode + "</span>\n" +
+                "<p style = \"display: flex; justify-content: flex-start; margin-left:50px; font-weight:900; font-family: Roboto; margin-bottom: 100px;\">감사합니다.</p>\n" +
+                "<p style = \"color: #96979C; display: flex; justify-content: flex-start; margin-left:50px; font-weight:900; font-family: Roboto; font-size: 10px;\">* 귀하가 한 행동이 아니라면 이 이메일을 무시하셔도 됩니다.</p>\n";
 
         MimeMessage message = emailSender.createMimeMessage();
         message.setFrom(new InternetAddress("sonshumc75@gmail.com", "Family Moments")); //발신자 설정
@@ -111,7 +111,7 @@ public class EmailService {
         if(!checkNameAndEmail(req)) {
             throw new BaseException(FIND_FAIL_USER_NAME_EMAIL);
         }
-        
+
         // 유효 시간이 만료된 경우
         if(!redisService.hasKey("VC("+ req.getEmail() + "):")) {
             throw new BaseException(VERIFICATION_TIME_EXPIRED);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailService.java
@@ -112,6 +112,11 @@ public class EmailService {
             throw new BaseException(FIND_FAIL_USER_NAME_EMAIL);
         }
 
+        // 인증 코드를 입력하지 않은 경우
+        if(req.getCode().isEmpty()) {
+            throw new BaseException(EMPTY_VERIFICATION_CODE);
+        }
+
         // 유효 시간이 만료된 경우
         if(!redisService.hasKey("VC("+ req.getEmail() + "):")) {
             throw new BaseException(VERIFICATION_TIME_EXPIRED);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -216,15 +216,15 @@ public class UserService {
 //        if (userFamilyList.isEmpty()) {
 //            throw new InternalServerErrorException("초대 요청이 존재하지 않습니다.");
 //        } else {
-            for (UserFamily invitation : userFamilyList) {
-                GetInvitationRes getInvitationRes = new GetInvitationRes(invitation.getFamilyId().getFamilyName(),
-                        // invitation.getFamilyId().getOwner().getNickname(),
-                        // invitation.getFamilyId().getOwner().getProfileImg());
-                        invitation.getInviteUserId().getNickname(),
-                        invitation.getInviteUserId().getProfileImg());
+        for (UserFamily invitation : userFamilyList) {
+            GetInvitationRes getInvitationRes = new GetInvitationRes(invitation.getFamilyId().getFamilyName(),
+                    // invitation.getFamilyId().getOwner().getNickname(),
+                    // invitation.getFamilyId().getOwner().getProfileImg());
+                    invitation.getInviteUserId().getNickname(),
+                    invitation.getInviteUserId().getProfileImg());
 
-                getInvitationResList.add(getInvitationRes);
-            }
+            getInvitationResList.add(getInvitationRes);
+        }
 //        }
 
         return getInvitationResList;

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostEmailReq.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/model/PostEmailReq.java
@@ -21,7 +21,6 @@ public class PostEmailReq {
         @NotBlank(message = "인증 코드를 받으실 이메일을 입력해주세요.")
         @Schema(description = "이메일", example = "family@gmail.com")
         private String email;
-        @NotBlank(message = "받은 인증 코드를 입력해주세요.")
         @Schema(description = "인증 코드", example = "여섯 자리 숫자로 이루어진 임의의 인증 코드")
         private String code;
     }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 인증 코드 공백 입력 오류 관련 에러 메세지 추가
- [x] 버그 수정 : 본인인증 메일 발송 API에서 code의 `@NotBlank` 삭제 후 `empty`로 전환 (#171)
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- `@NotBlank`를 사용하면 이메일을 보내는 시점에 이미 코드가 입력되어 있어야 하는 문제가 발생

### 작업 내역

- 본인인증 메일 발송 API에서 code의 `@NotBlank` 삭제 후 `empty`로 전환
