### PR TITLE
refactor: PostController의 불필요한 try-catch문 삭제

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -66,12 +66,8 @@ public class PostController {
                 .content(postInfoReq.getContent())
                 .build();
 
-        try {
-            SinglePostRes singlePostRes = postService.createPost(user, postReq);
-            return new BaseResponse<>(singlePostRes);
-        } catch (RuntimeException e) {
-            return new BaseResponse<>(FIND_FAIL_FAMILY);
-        }
+        SinglePostRes singlePostRes = postService.createPost(user, postReq);
+        return new BaseResponse<>(singlePostRes);
     }
 
     /**

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -69,8 +69,6 @@ public class PostController {
         try {
             SinglePostRes singlePostRes = postService.createPost(user, postReq);
             return new BaseResponse<>(singlePostRes);
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
         } catch (RuntimeException e) {
             return new BaseResponse<>(FIND_FAIL_FAMILY);
         }
@@ -101,12 +99,9 @@ public class PostController {
                 .imgs(imgs)
                 .build();
 
-        try {
-            SinglePostRes singlePostRes = postService.editPost(user, postId, postReq);
-            return new BaseResponse<>(singlePostRes);
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
+        SinglePostRes singlePostRes = postService.editPost(user, postId, postReq);
+        return new BaseResponse<>(singlePostRes);
+
     }
 
     /**
@@ -118,12 +113,8 @@ public class PostController {
     @DeleteMapping("/{postId}")
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
     public BaseResponse<SinglePostRes> editPost(@AuthenticationPrincipal @Parameter(hidden = true) User user, @PathVariable long postId) {
-        try {
-            postService.deletePost(user, postId);
-            return new BaseResponse<>(SUCCESS);
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
+        postService.deletePost(user, postId);
+        return new BaseResponse<>(SUCCESS);
     }
 
     /**
@@ -135,12 +126,8 @@ public class PostController {
     @GetMapping(params = {"familyId"})
     @Operation(summary = "게시글 10건 조회", description = "최근 10개의 게시글을 조회합니다.")
     public BaseResponse<List<SinglePostRes>> getRecentPosts(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestParam("familyId") long familyId) {
-        try {
-            List<SinglePostRes> singlePostRes = postService.getPosts(user, familyId);
-            return new BaseResponse<>(singlePostRes);
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
+        List<SinglePostRes> singlePostRes = postService.getPosts(user, familyId);
+        return new BaseResponse<>(singlePostRes);
     }
 
     /**
@@ -152,12 +139,8 @@ public class PostController {
     @GetMapping(params = {"familyId", "postId"})
     @Operation(summary = "게시글 수정(with paging)", description = "커서 이전의 게시물 10건을 조회합니다.")
     public BaseResponse<List<SinglePostRes>> getNextPosts(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestParam("familyId") long familyId, @RequestParam("postId") long postId) {
-        try {
-            List<SinglePostRes> singlePostRes = postService.getPosts(user, familyId, postId);
-            return new BaseResponse<>(singlePostRes);
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
+        List<SinglePostRes> singlePostRes = postService.getPosts(user, familyId, postId);
+        return new BaseResponse<>(singlePostRes);
     }
 
     /**
@@ -169,13 +152,8 @@ public class PostController {
     @GetMapping("/{postId}")
     @Operation(summary = "게시글 조회", description = "게시글 1건을 조회합니다.")
     public BaseResponse<SinglePostRes> getPost(@AuthenticationPrincipal @Parameter(hidden = true) User user, @PathVariable long postId) {
-        try {
-            SinglePostRes singlePostRes = postService.getPost(user, postId);
-
-            return new BaseResponse<>(singlePostRes);
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
+        SinglePostRes singlePostRes = postService.getPost(user, postId);
+        return new BaseResponse<>(singlePostRes);
     }
 
     /**
@@ -191,12 +169,8 @@ public class PostController {
                                                               @RequestParam("year") int year,
                                                               @RequestParam("month") int month,
                                                               @RequestParam("day") int day) {
-        try {
-            List<SinglePostRes> singlePostRes = postService.getPostsOfDate(user, familyId, year, month, day);
-            return new BaseResponse<>(singlePostRes);
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
+        List<SinglePostRes> singlePostRes = postService.getPostsOfDate(user, familyId, year, month, day);
+        return new BaseResponse<>(singlePostRes);
     }
 
     /**
@@ -213,12 +187,8 @@ public class PostController {
                                                               @RequestParam("month") int month,
                                                               @RequestParam("day") int day,
                                                               @RequestParam("postId") long postId) {
-        try {
-            List<SinglePostRes> singlePostRes = postService.getPostsOfDate(user, familyId, year, month, day, postId);
-            return new BaseResponse<>(singlePostRes);
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
+        List<SinglePostRes> singlePostRes = postService.getPostsOfDate(user, familyId, year, month, day, postId);
+        return new BaseResponse<>(singlePostRes);
     }
 
     /**
@@ -234,12 +204,8 @@ public class PostController {
        }
 
        List<LocalDate> dates = null;
-       try {
-           dates = postService.getDayExistsPost(familyId, year, month);
-           return new BaseResponse<>(dates);
-       } catch (BaseException e) {
-           return new BaseResponse<>(e.getStatus());
-       }
+       dates = postService.getDayExistsPost(familyId, year, month);
+       return new BaseResponse<>(dates);
    }
 
     /**
@@ -250,12 +216,8 @@ public class PostController {
     @GetMapping(value = "/album")
     @Operation(summary = "앨범 30건 조회", description = "최근 30건의 게시물을 앨범 형태에 맞춰 조회합니다.")
     public BaseResponse<List<AlbumRes>> getRecentAlbum(@RequestParam("familyId") long familyId) {
-        try {
-            List<AlbumRes> album = postService.getAlbum(familyId);
-            return new BaseResponse<>(album);
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
+        List<AlbumRes> album = postService.getAlbum(familyId);
+        return new BaseResponse<>(album);
     }
 
     /**
@@ -266,12 +228,8 @@ public class PostController {
     @GetMapping(value = "/album", params = {"familyId", "postId"})
     @Operation(summary = "앨범 30건 조회(with paging)", description = "커서 이전의 30건의 게시물을 앨범 형태에 맞춰 조회합니다.")
     public BaseResponse<List<AlbumRes>> getRecentAlbum(@RequestParam("familyId") long familyId, @RequestParam("postId") long postId) {
-        try {
-            List<AlbumRes> album = postService.getAlbum(familyId, postId);
-            return new BaseResponse<>(album);
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
+        List<AlbumRes> album = postService.getAlbum(familyId, postId);
+        return new BaseResponse<>(album);
     }
 
     /**
@@ -282,12 +240,8 @@ public class PostController {
     @GetMapping(value = "/album/{postId}")
     @Operation(summary = "앨범 상세 조회", description = "앨범의 상세 페이지를 조회합니다.")
     public BaseResponse<List<String>> getAlbumImages(@PathVariable long postId) {
-        try {
-            List<String> imgs = postService.getPostImages(postId);
-            return new BaseResponse<>(imgs);
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
+        List<String> imgs = postService.getPostImages(postId);
+        return new BaseResponse<>(imgs);
     }
 
     /**
@@ -298,13 +252,8 @@ public class PostController {
     @GetMapping("/{postId}/post-loves")
     @Operation(summary = "좋아요 명단 조회", description = "특정 게시물의 좋아요를 누른 사람의 명단을 조회합니다.")
     public BaseResponse<List<PostLoveRes>> getLovedList(@PathVariable long postId) {
-        try {
-            List<PostLoveRes> heartedList = postLoveService.getHeartList(postId);
-
-            return new BaseResponse<>(heartedList);
-        } catch (BaseException e) {
-            return new BaseResponse<>(e.getStatus());
-        }
+        List<PostLoveRes> heartedList = postLoveService.getHeartList(postId);
+        return new BaseResponse<>(heartedList);
     }
 
     /**


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : PostController의 불필요한 try-catch문 삭제
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
- 유지되고 있던 PostController 내부의 BaseException try-catch을 삭제하였습니다.
- createPost 메소드에 존재했던 RuntimeException try-catch의 경우,
service에서 더이상 RuntimeException을 throw하지 않아 삭제하였습니다.
([#bb2c8b1](https://github.com/familymoments/family-moments-BE/commit/bb2c8b1169ee2f0a8fc89174ef716508599b420c) 커밋 참조)
