### PR TITLE
fix: 회원탈퇴- 가족구성원 1명인데, 그 1명이 owner일 때 탈퇴 가능

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
@@ -26,6 +26,8 @@ public interface UserFamilyRepository extends JpaRepository<UserFamily, Long> {
     //회원 탈퇴 시, UserFamily 매핑 테이블 해제를 위한 조회
     @Query("SELECT uf FROM UserFamily uf WHERE uf.userId.userId = :userId")
     List<UserFamily> findUserFamilyByUserId(@Param("userId") Long userId);
+    @Query("SELECT uf FROM UserFamily uf WHERE uf.familyId.familyId = :familyId")
+    List<UserFamily> findUserFamilyByFamilyId(@Param("familyId") Long familyId);
 
     @Query(value = "SELECT u.userId AS userId, u.id AS id, u.nickname AS nickname, u.profileImg AS profileImg " +
             "FROM User u " +


### PR DESCRIPTION
### 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 회원탈퇴- 가족구성원 1명인데, 그 1명이 owner일 때 탈퇴 가능
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 회원탈퇴- 가족구성원 1명인데, 그 1명이 owner일 때 탈퇴 가능하고 가족도 삭제시킴.


### 작업 후 기대 동작(스크린샷)

- response는 동일합니다.
