### PR TITLE
feat: 이미지 리사이징 (썸네일 생성)

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/awsS3/AwsS3Controller.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/awsS3/AwsS3Controller.java
@@ -2,9 +2,9 @@ package com.spring.familymoments.domain.awsS3;
 
 import com.spring.familymoments.config.BaseException;
 import com.spring.familymoments.config.BaseResponse;
+import com.spring.familymoments.config.NoAuthCheck;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,6 +27,7 @@ public class AwsS3Controller {
     @ResponseBody
     @PostMapping("/image")
     @Operation(summary = "이미지 등록", description = "이미지 한 개를 S3에 등록하고 URL을 반환합니다.")
+    @NoAuthCheck
     public BaseResponse<String> uploadImage(@RequestParam(name = "image") MultipartFile image) throws BaseException {
         String fileUrl = awsS3Service.uploadImage(image);
         return new BaseResponse<>(fileUrl);
@@ -35,6 +36,7 @@ public class AwsS3Controller {
     @ResponseBody
     @PostMapping("/images")
     @Operation(summary = "다중 이미지 등록", description = "이미지 여러 개를 S3에 등록하고 URL을 반환합니다.")
+    @NoAuthCheck
     public BaseResponse<List<String>> uploadImages(@RequestPart(required = false) List<MultipartFile> images) throws BaseException {
         List<String> fileUrls = awsS3Service.uploadImages(images);
         return new BaseResponse<>(fileUrls);
@@ -43,7 +45,8 @@ public class AwsS3Controller {
     @ResponseBody
     @DeleteMapping("")
     @Operation(summary = "이미지 삭제", description = "이미지를 S3에서 삭제합니다.")
-    public BaseResponse<String> deleteImage(String fileName) {
+    @NoAuthCheck
+    public BaseResponse<String> deleteImage(@RequestParam(name = "url", required = true) String fileName) {
         try {
             awsS3Service.deleteImage(fileName);
             return new BaseResponse<>("성공했습니다.");

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
@@ -49,7 +49,7 @@ public class FamilyController {
             @AuthenticationPrincipal @Parameter(hidden = true) User user,
             @RequestParam(name = "representImg") MultipartFile representImg,
             @Valid @RequestPart PostFamilyReq postFamilyReq) {
-        String fileUrl = awsS3Service.uploadImage(representImg);        // 대표 이미지 넣기
+        String fileUrl = awsS3Service.uploadProfileImage(representImg);        // 대표 이미지 넣기
         PostFamilyRes postFamilyRes = familyService.createFamily(user, postFamilyReq, fileUrl);
         return new BaseResponse<>(postFamilyRes);
     }
@@ -235,7 +235,7 @@ public class FamilyController {
     public BaseResponse<FamilyRes> updateFamily(@PathVariable Long familyId,
                                                 @RequestParam(name = "representImg") MultipartFile representImg,
                                                 @Valid @RequestPart FamilyUpdateReq familyUpdateReq){
-        String fileUrl = awsS3Service.uploadImage(representImg);
+        String fileUrl = awsS3Service.uploadProfileImage(representImg);
         FamilyRes familyRes = familyService.updateFamily(familyId, familyUpdateReq, fileUrl);
         return new BaseResponse<>(familyRes);
     }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -95,7 +95,7 @@ public class UserController {
         String fileUrl = null;
 
         if (postUserReq.getProfileImg() == null) {
-            fileUrl = awsS3Service.uploadImage(profileImage);
+            fileUrl = awsS3Service.uploadProfileImage(profileImage);
         }
 
         postUserReq.setProfileImg(fileUrl);
@@ -287,7 +287,7 @@ public class UserController {
         if(profileImg == null || profileImg.isEmpty()) { //이미지 비어있으면 원래 이미지 넣어주기
             patchProfileReqRes.setProfileImg(user.getProfileImg());
         } else {
-            String fileUrl = awsS3Service.uploadImage(profileImg);
+            String fileUrl = awsS3Service.uploadProfileImage(profileImg);
             patchProfileReqRes.setProfileImg(fileUrl);
         }
         if(patchProfileReqRes.getName() == null || patchProfileReqRes.getName().isEmpty()) { //이름 비어있으면


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 : 
- [ ] 버그 수정 :
- [x] 리펙토링 : 이미지 리사이징 기능을 위한 s3 경로 수정
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- s3 버킷 업로드 경로 변경
  - s3 버킷의 `fm-origin` 디렉토리에 업로드한 경우에만 resizing 작업이 실행됨
  - 리사이징된 이미지는 `thumbnails` 디렉토리에 저장되며, DB에 저장되는 url은 썸네일을 기본으로 함
  - 원본 이미지가 필요한 경우, 이미지의 url 경로에서 `thumbnails`을 `fm-origin`으로 교체
    - 예시
      - 썸네일 : `https://sample-bucket.com/thumbnails/filename.jpg`
      - 원본 : `https://sample-bucket.com/fm-origin/filename.jpg`
- S3 API 중 Delete API의 누락된 Annotation 추가
- S3 Controller - `NoAuthCheck` 처리

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
- S3 Controller에서의 Token 검증이 어색한 부분이 있어 임의로 `NoAuthCheck` 처리를 해두었습니다.
최소한의 검증이 필요하다고 판단되면 롤백하겠습니다. 
- Delete API의 경우 API 매개변수에 어노테이션 처리가 되어 있지 않아 PathVariable인지, QueryString인지 파악이 불가능해 임의로 어노테이션을 붙였습니다.

### 추가 건의사항
- 프로필 이미지의 경우 별도의 메소드를 사용해야해서 User Domain을 수정하던 중, 수정하면 좋을 듯한 부분이 보여 같이 언급합니다.
**아래 내용과 관련해서 다들 의견 꼭 남겨주세요!** 
  - User Controller에서의 DTO의 검증이 Controller에서 처리가 이루어지고 있는데, 해당 내용 `@Valid` 어노테이션으로 처리가 가능할 것 같습니다. (ex: 값이 비었는지, 값의 형식 검증 등)
  - 프로필 이미지를 s3에 업로드하는 내용의 경우, Controller보단 Service단에서 처리가 이루어지는 게 좋지 않나 싶습니다! (User, Family 모두 Controller에서 처리됨)
   
