### PR TITLE
fix: 일부 게시물 조회 API의 좋아요 정보 에러 수정

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -213,10 +213,13 @@ public class PostService {
             throw new BaseException(minnie_POSTS_NON_EXISTS_POST);
         }
 
+        // 로그인 유저의 post love 정보 받아오기
+        Long loginUser = user.getUserId();
+
         List<SinglePostRes> posts = new ArrayList<>();
         for(Post p: filteredPosts){
             SinglePostDocumentRes singlePostDocumentRes = postDocumentRepository.findByEntityId(p.getPostId());
-            boolean isLoved = postLoveService.checkPostLoveByUser(p.getPostId(), p.getWriter().getUserId());
+            boolean isLoved = postLoveService.checkPostLoveByUser(p.getPostId(), loginUser);
             boolean isWritten = p.isWriter(user);
 
             Long filteredPostId = p.getPostId();
@@ -294,10 +297,13 @@ public class PostService {
             throw new BaseException(minnie_POSTS_NON_EXISTS_POST);
         }
 
+        // 로그인 유저의 post love 정보 받아오기
+        Long loginUser = user.getUserId();
+
         List<SinglePostRes> posts = new ArrayList<>();
         for(Post p: filteredPosts){
             SinglePostDocumentRes singlePostDocumentRes = postDocumentRepository.findByEntityId(p.getPostId());
-            boolean isLoved = postLoveService.checkPostLoveByUser(p.getPostId(), p.getWriter().getUserId());
+            boolean isLoved = postLoveService.checkPostLoveByUser(p.getPostId(), loginUser);
             boolean isWritten = p.isWriter(user);
 
             Long filteredPostId = p.getPostId();
@@ -406,12 +412,15 @@ public class PostService {
             throw new BaseException(minnie_POSTS_NON_EXISTS_POST);
         }
 
+        // 로그인 유저의 post love 정보 받아오기
+        Long loginUser = user.getUserId();
+
         List<SinglePostRes> posts = new ArrayList<>();
         for(Post p: filteredPosts){
             // 2. 1단계에서 구한 post 목록의 postId와 일치하는 post document 받아오기
             SinglePostDocumentRes singlePostDocumentRes = postDocumentRepository.findByEntityId(p.getPostId());
             // 3. 로그인 유저의 post love 정보 받아오기
-            boolean isLoved = postLoveService.checkPostLoveByUser(p.getPostId(), p.getWriter().getUserId());
+            boolean isLoved = postLoveService.checkPostLoveByUser(p.getPostId(), loginUser);
             // 4. 로그인 유저가 게시물의 작성자인지 확인하기
             boolean isWritten = p.isWriter(user);
 
@@ -442,10 +451,13 @@ public class PostService {
     private List<SinglePostRes> getCombinedPostsByDate(User user, long familyId, LocalDateTime dateTime, Pageable pageable) {
         List<Post> filteredPosts = postRepository.findByFamilyIdAndCreatedAtDesc(familyId, dateTime, pageable);
 
+        // 로그인 유저의 post love 정보 받아오기
+        Long loginUser = user.getUserId();
+
         List<SinglePostRes> posts = new ArrayList<>();
         for(Post p: filteredPosts){
             SinglePostDocumentRes singlePostDocumentRes = postDocumentRepository.findByEntityId(p.getPostId());
-            boolean isLoved = postLoveService.checkPostLoveByUser(p.getPostId(), p.getWriter().getUserId());
+            boolean isLoved = postLoveService.checkPostLoveByUser(p.getPostId(), loginUser);
             boolean isWritten = p.isWriter(user);
 
             Long filteredPostId = p.getPostId();


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [X] 버그 수정 : 일부 게시물 조회 API에서 좋아요가 제대로 뜨지 않던 에러 수정 (#166)
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 게시물 수정 API 에서는 작성자의 정보로 `postLove`를 검색해도 상관이 없는 반면, 게시물 조회 API 들에서는 작성자의 정보가 아니라 로그인 유저의 정보로 `postLove`를 검색해야 한다는 부분을 놓쳐 발생한 오류였습니다! 😢  

### 작업 내역

- 작성자가 아닌 로그인 유저로 `postLove`를 검색하도록 수정했습니다!

### 작업 후 기대 동작(스크린샷)

- 이전과 같습니다. (#166)

### PR 특이 사항

- **2차 QA 중 '게시글 좋아요 오류' 와 관련**된 PR 입니다!