### PR TITLE
fix : 회원 탈퇴 soft delete + 로그인/회원 가입 시 active 확인

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/alarmSetting/AlarmSettingRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/alarmSetting/AlarmSettingRepository.java
@@ -4,8 +4,10 @@ import com.spring.familymoments.domain.alarmSetting.entity.AlarmSetting;
 import com.spring.familymoments.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AlarmSettingRepository extends JpaRepository<AlarmSetting, Long> {
     Optional<AlarmSetting> findByUserAndAlarmType(User user, AlarmSetting.AlarmType alarmType);
+    List<AlarmSetting> findAlarmSettingByUser(User user);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentReportRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentReportRepository.java
@@ -1,7 +1,11 @@
 package com.spring.familymoments.domain.comment;
 
 import com.spring.familymoments.domain.comment.entity.CommentReport;
+import com.spring.familymoments.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentReportRepository extends JpaRepository<CommentReport, Long>  {
+    List<CommentReport> findCommentReportByUser(User user);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/entity/Comment.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/entity/Comment.java
@@ -28,7 +28,7 @@ public class Comment extends BaseEntity {
     private Long commentId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "writer", nullable = false)
+    @JoinColumn(name = "writer")
     private User writer;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -51,6 +51,13 @@ public class Comment extends BaseEntity {
      */
     public void updateStatus(Status status) {
         this.status = status;
+    }
+
+    /***
+     * SET NULL -> 추후 변경 예정
+     */
+    public void updateWriter() {
+        this.writer = null;
     }
 
     /**

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/entity/CommentReport.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/entity/CommentReport.java
@@ -23,7 +23,7 @@ public class CommentReport extends BaseEntity {
     private Long commentReportId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId", nullable = false)
+    @JoinColumn(name = "userId")
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -43,6 +43,13 @@ public class CommentReport extends BaseEntity {
                 .reportReason(reportReason)
                 .details(details)
                 .build();
+    }
+
+    /***
+     * SET NULL -> 추후 변경 예정
+     */
+    public void updateUser() {
+        this.user = null;
     }
 
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
@@ -26,7 +26,7 @@ public interface UserFamilyRepository extends JpaRepository<UserFamily, Long> {
     //회원 탈퇴 시, UserFamily 매핑 테이블 해제를 위한 조회
     @Query("SELECT uf FROM UserFamily uf WHERE uf.userId.userId = :userId")
     List<UserFamily> findUserFamilyByUserId(@Param("userId") Long userId);
-    @Query("SELECT uf FROM UserFamily uf WHERE uf.familyId.familyId = :familyId")
+    @Query("SELECT uf FROM UserFamily uf WHERE uf.familyId.familyId = :familyId AND uf.status = 'ACTIVE' ")
     List<UserFamily> findUserFamilyByFamilyId(@Param("familyId") Long familyId);
 
     @Query(value = "SELECT u.userId AS userId, u.id AS id, u.nickname AS nickname, u.profileImg AS profileImg " +

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
@@ -19,6 +19,7 @@ public interface FamilyRepository extends JpaRepository<Family, Long> {
     Optional<Family> findByInviteCode(String inviteCode);
 
     //회원 탈퇴 시, 가족 생성자 권한 여부를 확인하기 위한 조회
+    @Query("SELECT f FROM Family f WHERE f.owner = :user AND f.owner.status = 'ACTIVE' ")
     List<Family> findByOwner(User user);
 
     @Query("SELECT CASE WHEN COUNT(uf) = 0 THEN false ELSE true END " +

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostReportRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostReportRepository.java
@@ -1,7 +1,11 @@
 package com.spring.familymoments.domain.post;
 
 import com.spring.familymoments.domain.post.entity.PostReport;
+import com.spring.familymoments.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostReportRepository extends JpaRepository<PostReport, Long> {
+    List<PostReport> findPostReportByUser(User user);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/PostReport.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/PostReport.java
@@ -20,7 +20,7 @@ public class PostReport extends BaseEntity {
     private Long postReportId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId", nullable = false)
+    @JoinColumn(name = "userId")
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -40,6 +40,13 @@ public class PostReport extends BaseEntity {
                 .reportReason(reportReason)
                 .details(details)
                 .build();
+    }
+
+    /**
+     * 게시글 신고 null 처리
+     */
+    public void updateUser() {
+        this.user = null;
     }
 
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface PostLoveRepository extends JpaRepository<PostLove, Long> {
+public interface git lPostLoveRepository extends JpaRepository<PostLove, Long> {
 
     Optional<PostLove> findByPostIdAndUserId(Post post, User user);
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/postLove/PostLoveRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface git lPostLoveRepository extends JpaRepository<PostLove, Long> {
+public interface PostLoveRepository extends JpaRepository<PostLove, Long> {
 
     Optional<PostLove> findByPostIdAndUserId(Post post, User user);
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserController.java
@@ -62,7 +62,7 @@ public class SocialUserController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK")
     })
-    public ResponseEntity<BaseResponse<SocialJoinResponse>> createSocialUser(@Parameter(description = "신규 회원의 가입 정보") @RequestPart("userJoinReq") UserJoinRequest userJoinRequest,
+    public ResponseEntity<?> createSocialUser(@Parameter(description = "신규 회원의 가입 정보") @RequestPart("userJoinReq") UserJoinRequest userJoinRequest,
                                               @Parameter(description = "신규 회원의 프로필 첨부파일") @RequestPart("profileImg") MultipartFile profileImage) {
         SocialJoinDto socialJoinDto = socialUserService.createSocialUser(userJoinRequest, profileImage);
 
@@ -70,13 +70,19 @@ public class SocialUserController {
         String accessToken = (tokenDto != null) ? tokenDto.getAccessToken() : null;
         String refreshToken = (tokenDto != null) ? tokenDto.getRefreshToken() : null;
 
-        return ResponseEntity.ok()
+        ResponseEntity.BodyBuilder responseBuilder =  ResponseEntity.ok()
                 .header("X-AUTH-TOKEN", accessToken)
-                .header("REFRESH-TOKEN", refreshToken)
-                .body(
-                        new BaseResponse<>(SocialJoinResponse.of(
-                        socialJoinDto.getFamilyId()))
-                );
+                .header("REFRESH-TOKEN", refreshToken);
+
+        if(socialJoinDto.getFamilyId() != null) {
+            return responseBuilder.body(new BaseResponse<>(
+                    SocialJoinResponse.of(socialJoinDto.getFamilyId())
+            ));
+        } else {
+            return responseBuilder.body(new BaseResponse<>(
+                    "회원가입을 성공했습니다."
+            ));
+        }
     }
 
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserRepository.java
@@ -13,8 +13,9 @@ import java.util.Optional;
 @Repository
 public interface SocialUserRepository extends JpaRepository<SocialInfo, Long> {
     //rest api/sdk version
-    @Query("SELECT u FROM User u LEFT JOIN SocialInfo si ON u = si.user WHERE u.email = :email AND si.type = :userType")
+    @Query("SELECT u FROM User u LEFT JOIN SocialInfo si ON u = si.user WHERE u.email = :email AND si.type = :userType And si.status = 'ACTIVE' AND u.status = 'ACTIVE' ")
     Optional<User> findUserByEmailAndUserType(@Param("email") String email, @Param("userType") UserType userType);
 
+    @Query("SELECT si FROM SocialInfo si WHERE si.user = :user AND si.status = 'ACTIVE' ")
     List<SocialInfo> findSocialInfoByUser(User user);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/SocialUserService.java
@@ -96,7 +96,7 @@ public class SocialUserService {
             String strBirthDate = null;
 
             //기존회원 토큰발급 (회원가입 필요없음)
-            if(existedU != null && existedU.isPresent()) {
+            if(existedU != null && existedU.isPresent() && existedU.get().getStatus() == User.Status.ACTIVE) {
                 isExisted = true;
                 tokenDto = setAuthenticationInSocial(existedU.get());
                 //familyId 반환
@@ -156,7 +156,7 @@ public class SocialUserService {
             throw new BaseException(POST_USERS_INVALID_ID);
         }
         //아이디 중복 체크
-        if (userService.checkDuplicateId(userJoinRequest.getId())) {
+        if (userService.checkDuplicateIdByStatus(userJoinRequest.getId())) {
             throw new BaseException(POST_USERS_EXISTS_ID);
         }
         //이름

--- a/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/entity/SocialInfo.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/socialInfo/entity/SocialInfo.java
@@ -26,16 +26,16 @@ public class SocialInfo extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "snsInfoId", nullable = false, updatable = false)
     private Long snsInfoId;
-    @ManyToOne(fetch = FetchType.EAGER)
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user", nullable = false)
     private User user;
+
     @Column(name = "type", nullable = false, length = 10)
     private UserType type = UserType.NORMAL;
 
-    @ColumnDefault("temp")
     @Builder.Default()
-    @Column(columnDefinition = "TEXT", nullable = false)
-    private String snsUserId = "temp";
+    private String snsUserId  = "temp";
 
     /**
      * 회원 탈퇴 API 관련 메소드

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/AuthService.java
@@ -48,10 +48,10 @@ public class AuthService {
      */
     public TokenDto login(PostLoginReq postLoginReq) {
         User user = userRepository.findById(postLoginReq.getId())
-                .orElseThrow(() -> new BaseException(FAILED_TO_LOGIN_ID)); //아이디가 일치하지 않습니다.
-        if(user.getStatus().equals(User.Status.INACTIVE)) {
-            throw new BaseException(FAILED_TO_LOGIN); //탈퇴하거나 신고당한 유저입니다.
-        }
+                .orElseThrow(() -> new BaseException(FAILED_TO_LOGIN_ID)); //아이디가 일치하지 않습니다. //탈퇴하거나 신고당한 유저입니다.
+        //if(user.getStatus().equals(User.Status.INACTIVE)) {
+        //    throw new BaseException(FAILED_TO_LOGIN);
+        //}
         if(!passwordEncoder.matches(postLoginReq.getPassword(), user.getPassword())) {
             throw new BaseException(FAILED_TO_LOGIN_PWD); //비밀번호가 일치하지 않습니다.
         }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailController.java
@@ -44,7 +44,7 @@ public class EmailController {
         }
 
         try{
-            if(emailService.checkNameAndEmail(sendEmailReq)){
+            if(emailService.checkNameAndEmailByStatus(sendEmailReq)){
                 String verificationCode = emailService.sendEmail(sendEmailReq.getName(), sendEmailReq.getEmail());
                 return new BaseResponse<>("입력하신 이메일로 인증 코드가 전송되었습니다.");
             } else {

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailService.java
@@ -15,6 +15,7 @@ import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import java.io.UnsupportedEncodingException;
+import java.util.List;
 import java.util.Objects;
 
 import static com.spring.familymoments.config.BaseResponseStatus.*;
@@ -96,8 +97,22 @@ public class EmailService {
      * [GET]
      * @return 일치하는 회원 정보가 존재하면 true, 그렇지 않으면 false
      */
-    public boolean checkNameAndEmail(PostEmailReq.sendVerificationEmail req) {
+    /*public boolean checkNameAndEmail(PostEmailReq.sendVerificationEmail req) {
         return userRepository.existsByNameAndEmail(req.getName(), req.getEmail());
+    }*/
+
+    /**
+     * 아이디/비밀번호 찾기 -> 입력한 이름, 이메일과 일치하는 회원 정보가 있는지 확인
+     * [GET]
+     * @return 일치하는 회원 정보가 존재하면 true, 그렇지 않으면 false
+     */
+    public boolean checkNameAndEmailByStatus(PostEmailReq.sendVerificationEmail req) {
+        boolean alreadyUser = true;
+        List<User> userList = userRepository.findUserByNameAndEmail(req.getName(), req.getEmail());
+        if(userList.isEmpty()) {
+            alreadyUser = false;
+        }
+        return alreadyUser;
     }
 
     /**
@@ -108,7 +123,7 @@ public class EmailService {
     public boolean checkVerificationCode(PostEmailReq.sendVerificationEmail req) throws BaseException {
 
         // 일치하는 회원 정보가 없는 경우
-        if(!checkNameAndEmail(req)) {
+        if(!checkNameAndEmailByStatus(req)) {
             throw new BaseException(FIND_FAIL_USER_NAME_EMAIL);
         }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/EmailService.java
@@ -17,6 +17,7 @@ import javax.mail.internet.MimeMessage;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.spring.familymoments.config.BaseResponseStatus.*;
 
@@ -107,12 +108,8 @@ public class EmailService {
      * @return 일치하는 회원 정보가 존재하면 true, 그렇지 않으면 false
      */
     public boolean checkNameAndEmailByStatus(PostEmailReq.sendVerificationEmail req) {
-        boolean alreadyUser = true;
-        List<User> userList = userRepository.findUserByNameAndEmail(req.getName(), req.getEmail());
-        if(userList.isEmpty()) {
-            alreadyUser = false;
-        }
-        return alreadyUser;
+        Optional<User> user = userRepository.findByNameAndEmail(req.getName(), req.getEmail());
+        return user.isPresent();
     }
 
     /**

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -66,7 +66,7 @@ public class UserController {
             return new BaseResponse<>(POST_USERS_INVALID_ID);
         }
         // TODO: 아이디 중복 체크
-        if (userService.checkDuplicateId(postUserReq.getId())) {
+        if (userService.checkDuplicateIdByStatus(postUserReq.getId())) {
             // log.info("[createUser]: 이미 존재하는 아이디입니다!");
             return new BaseResponse<>(POST_USERS_EXISTS_ID);
         }
@@ -79,7 +79,7 @@ public class UserController {
             return new BaseResponse<>(POST_USERS_INVALID_EMAIL);
         }
         // TODO: 이메일 중복 체크
-        if (userService.checkDuplicateEmail(postUserReq.getEmail())) {
+        if (userService.checkDuplicateEmailByStatus(postUserReq.getEmail())) {
             // log.info("[createUser]: 이미 존재하는 이메일입니다!");
             return new BaseResponse<>(POST_USERS_EXISTS_EMAIL);
         }
@@ -116,7 +116,7 @@ public class UserController {
     public BaseResponse<String> checkDuplicateId(@Parameter(description = "회원 가입할 때 중복 검사를 할 아이디")
                                                      @Valid @RequestBody GetDuplicateUserIdReq getDuplicateUserIdReq) {
 
-        if(!userService.checkDuplicateId(getDuplicateUserIdReq.getId())) {
+        if(!userService.checkDuplicateIdByStatus(getDuplicateUserIdReq.getId())) {
             return new BaseResponse<>("사용 가능한 아이디입니다.");
         } else {
             return new BaseResponse<>(POST_USERS_EXISTS_ID);
@@ -134,7 +134,7 @@ public class UserController {
     public BaseResponse<String> checkDuplicateEmail(@Parameter(description = "회원 가입할 때 중복 검사를 할 이메일")
                                                         @Valid @RequestBody GetDuplicateUserEmailReq getDuplicateUserEmailReq) {
 
-        if(!userService.checkDuplicateEmail(getDuplicateUserEmailReq.getEmail())) {
+        if(!userService.checkDuplicateEmailByStatus(getDuplicateUserEmailReq.getEmail())) {
             return new BaseResponse<>("사용 가능한 이메일입니다.");
         } else {
             return new BaseResponse<>(POST_USERS_EXISTS_EMAIL);
@@ -180,7 +180,7 @@ public class UserController {
                                                               @Valid @RequestBody GetUserIdReq getUserIdReq)
             throws MessagingException, BaseException {
 
-        if (userService.checkDuplicateId(getUserIdReq.getUserId())) {
+        if (userService.checkDuplicateIdByStatus(getUserIdReq.getUserId())) {
             // GetUserIdRes getUserIdRes = new GetUserIdRes(id);
             // return new BaseResponse<>(getUserIdRes);
             return new BaseResponse<>("입력하신 아이디로 가입을 확인했습니다. 본인 확인을 위하여 이메일로 인증해주세요.");
@@ -379,9 +379,8 @@ public class UserController {
                                                            @RequestParam String id) throws BaseException{
 
         String memberId = emailService.getUserId(id);
-
         try {
-            if(userService.checkDuplicateId(memberId)) {
+            if(userService.checkDuplicateIdByStatus(memberId)) {
                 // 새 비밀번호 형식
                 if(!isRegexPw(patchPwdWithoutLoginReq.getPasswordA()) || !isRegexPw(patchPwdWithoutLoginReq.getPasswordB())) {
                     return new BaseResponse<>(POST_USERS_INVALID_PW);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -430,7 +430,6 @@ public class UserController {
     })
     public BaseResponse<String> deleteUser(@AuthenticationPrincipal @Parameter(hidden = true) User user, @RequestHeader("X-AUTH-TOKEN") String requestAccessToken) {
         userService.deleteUserWithRedisProcess(user, requestAccessToken);
-        fcmService.deleteToken(user.getId());     // FCM Token 삭제
         return new BaseResponse<>("계정을 삭제했습니다.");
     }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
@@ -15,13 +15,19 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    @Query("SELECT u FROM User u WHERE u.userId = :userId " +
+            "AND u.status = 'ACTIVE' ")
     Optional<User> findUserByUserId(Long userId);
 
+    @Query("SELECT u FROM User u WHERE u.uuid = :uuid " +
+            "AND u.status = 'ACTIVE' ")
     Optional<User> findUserByUuid(String uuid);
 
     // Optional<User> findByEmailAndStatus(String email, BaseEntity.Status status);
-    Optional<User> findById(String id);
-    Optional<User> findByEmail(String email);
+    @Query("SELECT u FROM User u WHERE u.id = :id " +
+            "AND u.status = 'ACTIVE' ")
+    Optional<User> findById(@Param("id") String id);
+//    Optional<User> findByEmail(String email);
 
 //    boolean existsById(String id);
 //    boolean existsByName(String name);
@@ -29,23 +35,19 @@ public interface UserRepository extends JpaRepository<User, Long> {
 //    boolean existsByNameAndEmail(String name, String email);
 //    boolean existsByIdAndStatus(String id, User.Status Status);
 
-    @Query("SELECT u FROM User u WHERE u.id = :id " +
-            "AND u.status = 'ACTIVE' ")
-    List<User> findUserById(@Param("id") String id);
-
     @Query("SELECT u FROM User u WHERE u.email = :email AND u.name = :name " +
             "AND u.status = 'ACTIVE' ")
-    List<User> findUserByNameAndEmail(@Param("name") String name, @Param ("email")String email);
+    Optional<User> findByNameAndEmail(@Param("name") String name, @Param ("email")String email);
 
     @Query("SELECT u FROM User u WHERE u.email = :email " +
             "AND u.status = 'ACTIVE' ")
-    List<User> findUserByEmail(@Param("email") String email);
+    Optional<User> findByEmail(@Param("email") String email);
 
     //유저 검색
-    @Query("SELECT u FROM User u WHERE u.id LIKE :keyword% ORDER BY u.id ASC")
+    @Query("SELECT u FROM User u WHERE u.id LIKE :keyword% AND u.status = 'ACTIVE' ORDER BY u.id ASC ")
     List<User> searchUserByKeyword(String keyword);
     @Query("SELECT u, uf FROM User u LEFT JOIN UserFamily uf ON u.userId = uf.userId.userId " +
-            "WHERE (uf.familyId.familyId = :familyId) AND (u.userId = :userId)")
+            "WHERE (uf.familyId.familyId = :familyId) AND (u.userId = :userId) AND u.status = 'ACTIVE' AND uf.status = 'ACTIVE' ")
     List<Object[]> findUsersByFamilyIdAndUserId(Long familyId, Long userId);
 
     User findByNickname(String nickname);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -22,11 +23,23 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(String id);
     Optional<User> findByEmail(String email);
 
-    boolean existsById(String id);
-    boolean existsByName(String name);
-    boolean existsByEmail(String email);
-    boolean existsByNameAndEmail(String name, String email);
+//    boolean existsById(String id);
+//    boolean existsByName(String name);
+//    boolean existsByEmail(String email);
+//    boolean existsByNameAndEmail(String name, String email);
 //    boolean existsByIdAndStatus(String id, User.Status Status);
+
+    @Query("SELECT u FROM User u WHERE u.id = :id " +
+            "AND u.status = 'ACTIVE' ")
+    List<User> findUserById(@Param("id") String id);
+
+    @Query("SELECT u FROM User u WHERE u.email = :email AND u.name = :name " +
+            "AND u.status = 'ACTIVE' ")
+    List<User> findUserByNameAndEmail(@Param("name") String name, @Param ("email")String email);
+
+    @Query("SELECT u FROM User u WHERE u.email = :email " +
+            "AND u.status = 'ACTIVE' ")
+    List<User> findUserByEmail(@Param("email") String email);
 
     //유저 검색
     @Query("SELECT u FROM User u WHERE u.id LIKE :keyword% ORDER BY u.id ASC")

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -118,8 +118,22 @@ public class UserService {
      * [GET]
      * @return 이미 가입된 아이디면 -> true, 그렇지 않으면 -> false
      */
-    public boolean checkDuplicateId(String UserId) throws BaseException {
+    /*public boolean checkDuplicateId(String UserId) throws BaseException {
         return userRepository.existsById(UserId);
+    }*/
+
+    /**
+     * 아이디 중복 확인 ACTIVE 포함 ver.
+     * [GET]
+     * @return 이미 가입된 아이디면 -> true, 그렇지 않으면 -> false
+     */
+    public boolean checkDuplicateIdByStatus(String UserId) {
+        boolean alreadyUser = true;
+        List<User> activeMemberList = userRepository.findUserById(UserId);
+        if(activeMemberList.isEmpty()) {
+            alreadyUser = false;
+        }
+        return alreadyUser;
     }
 
 //    /**
@@ -135,13 +149,30 @@ public class UserService {
 //    }
 
     /**
-     * 이메일 중복 확인
+     * 이메일 중복 확인 ACTIVE 포함 ver.
      * [GET]
      * @return 이미 가입된 이메일이면 -> true, 그렇지 않으면 -> false
      */
-    public boolean checkDuplicateEmail(String email) throws BaseException {
+    /*public boolean checkDuplicateEmail(String email) throws BaseException {
         return userRepository.existsByEmail(email);
+    }*/
+
+    /**
+     * 이메일 중복 확인 ACTIVE 포함 ver.
+     * [GET]
+     * 이미 가입된 이메일이면 -> true, 그렇지 않으면 false
+     * @param email
+     * @return
+     */
+    public boolean checkDuplicateEmailByStatus(String email) {
+        boolean alreadyUser = true;
+        List<User> activeMemberList = userRepository.findUserByEmail(email);
+        if(activeMemberList.isEmpty()) {
+            alreadyUser = false;
+        }
+        return alreadyUser;
     }
+
 
     /**
      * 회원정보 조회 API

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -2,28 +2,36 @@ package com.spring.familymoments.domain.user;
 
 import com.spring.familymoments.config.BaseException;
 import com.spring.familymoments.config.secret.jwt.JwtService;
+import com.spring.familymoments.domain.alarmSetting.AlarmSettingRepository;
 import com.spring.familymoments.domain.alarmSetting.AlarmSettingService;
+import com.spring.familymoments.domain.alarmSetting.entity.AlarmSetting;
+import com.spring.familymoments.domain.comment.CommentReportRepository;
 import com.spring.familymoments.domain.comment.CommentWithUserRepository;
 import com.spring.familymoments.domain.comment.entity.Comment;
+import com.spring.familymoments.domain.comment.entity.CommentReport;
 import com.spring.familymoments.domain.commentLove.CommentLoveWithUserRepository;
 import com.spring.familymoments.domain.commentLove.entity.CommentLove;
+import com.spring.familymoments.domain.common.BaseEntity;
 import com.spring.familymoments.domain.common.UserFamilyRepository;
 import com.spring.familymoments.domain.common.entity.UserFamily;
 import com.spring.familymoments.domain.family.FamilyRepository;
 import com.spring.familymoments.domain.family.entity.Family;
+import com.spring.familymoments.domain.fcm.FCMService;
+import com.spring.familymoments.domain.post.PostReportRepository;
 import com.spring.familymoments.domain.post.PostWithUserRepository;
 import com.spring.familymoments.domain.post.entity.Post;
+import com.spring.familymoments.domain.post.entity.PostReport;
 import com.spring.familymoments.domain.postLove.PostLoveRepository;
 import com.spring.familymoments.domain.postLove.entity.PostLove;
 import com.spring.familymoments.domain.redis.RedisService;
-//import com.spring.familymoments.domain.socialInfo.SocialUserService;
+import com.spring.familymoments.domain.socialInfo.*;
+import com.spring.familymoments.domain.socialInfo.entity.SocialInfo;
+import com.spring.familymoments.domain.socialInfo.model.GoogleDeleteDto;
 import com.spring.familymoments.domain.user.model.*;
 import com.spring.familymoments.domain.user.entity.User;
 import com.spring.familymoments.utils.UuidUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,7 +66,13 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final RedisService redisService;
     private final AlarmSettingService alarmSettingService;
-    //private final SocialUserService socialUserService;
+
+    private final PostReportRepository postReportRepository;
+    private final CommentReportRepository commentReportRepository;
+    private final SocialUserRepository socialUserRepository;
+    private final AlarmSettingRepository alarmSettingRepository;
+
+    private final FCMService fcmService;
 
     /**
      * createUser
@@ -324,28 +338,38 @@ public class UserService {
     /**
      * 회원 탈퇴 API
      * [DELETE] /users
+     *
+     * set null (탈퇴한 유저의 댓글 알수없음 / 탈퇴한 유저의 신고 내역(탈퇴한 유저가 신고한) 남김)
+     *
      * @return
      */
+    //soft delete
     @Transactional
     public void deleteUser(User user) {
-        Long userId = user.getUserId();
-
         //1) 가족 생성자면 예외처리
         List<Family> ownerFamilies = familyRepository.findByOwner(user);
         if(!ownerFamilies.isEmpty()) {
             //로그인 유저가 가족 생성자 + 가족 내에 본인 혼자일 때는 탈퇴 처리
             for(Family family : ownerFamilies) {
-                List<UserFamily> uf = userFamilyRepository.findUserFamilyByFamilyId(family.getFamilyId());
-                if(uf.size() == 1) {
-                    //가족 삭제 후 탈퇴 진행
-                    family.updateStatus(INACTIVE);
-                    familyRepository.save(family);
-                    continue;
+                //가족 ACTIVE 조건 추가
+                if(family.getStatus() == BaseEntity.Status.ACTIVE) {
+                    List<UserFamily> uf = userFamilyRepository.findUserFamilyByFamilyId(family.getFamilyId());
+                    if(uf.size() == 1) {
+                        //가족 삭제 후 탈퇴 진행
+                        family.updateStatus(INACTIVE);
+                        familyRepository.save(family);
+                        continue;
+                    }
+                    //생성자 권한을 다른 사람에게 넘겨야 탈퇴 가능
+                    throw new BaseException(FAILED_TO_LEAVE);
                 }
-                //생성자 권한을 다른 사람에게 넘겨야 탈퇴 가능
-                throw new BaseException(FAILED_TO_LEAVE);
             }
         }
+        commonDeleteProcess(user);
+    }
+
+    public void commonDeleteProcess(User user) {
+        Long userId = user.getUserId();
 
         //2) 로그인 유저의 댓글 좋아요 일괄 INACTIVE
         List<CommentLove> commentLoves = commentLoveWithUserRepository.findCommentLovesByUserId(userId);
@@ -359,11 +383,12 @@ public class UserService {
             postLove.updateStatus(INACTIVE);
         }
 
-        //4) 로그인 유저의 댓글 일괄 INACTIVE
+        //4) 로그인 유저의 댓글 '알수없음' 처리 (일괄 INACTIVE)
         List<Comment> comments = commentWithUserRepository.findCommentsByUserId(userId);
         for(Comment comment : comments) {
-            comment.updateStatus(INACTIVE);
+            comment.updateWriter();
         }
+
         //5) 로그인 유저의 게시글 일괄 INACTIVE
         List<Post> posts = postWithUserRepository.findPostByUserId(userId);
         for(Post post : posts) {
@@ -375,10 +400,36 @@ public class UserService {
         for(UserFamily userFamily : userFamilyList) {
             userFamily.updateStatus(UserFamily.Status.INACTIVE);
         }
-        //7) 로그인 유저 INACTIVE
+
+        //7) 소셜 정보 INACTIVE
+        List<SocialInfo> socialInfos = socialUserRepository.findSocialInfoByUser(user);
+        if(!socialInfos.isEmpty()) {
+            for (SocialInfo socialInfo : socialInfos) {
+                socialInfo.updateStatus(INACTIVE);
+            }
+        }
+
+        //8) 알람 세팅 INACTIVE
+        List<AlarmSetting> alarmSettingList = alarmSettingRepository.findAlarmSettingByUser(user);
+        for(AlarmSetting alarmSetting : alarmSettingList) {
+            alarmSetting.setStatus(INACTIVE);
+        }
+
+        //9) 게시글, 댓글 신고 관련 user null 처리 (탈퇴한 유저가 신고했던 내용만 남기기) -
+        List<CommentReport> commentReportList = commentReportRepository.findCommentReportByUser(user);
+        for(CommentReport commentReport : commentReportList) {
+            commentReport.updateUser();
+        }
+        List<PostReport> postReportList = postReportRepository.findPostReportByUser(user);
+        for(PostReport postReport : postReportList) {
+            postReport.updateUser();
+        }
+
+        //10) 로그인 유저 INACTIVE
         user.updateStatus(User.Status.INACTIVE);
         userRepository.save(user);
     }
+
     @Transactional
     public void deleteUserWithRedisProcess(User user, String requestAccessToken) {
         this.deleteUser(user);
@@ -391,22 +442,39 @@ public class UserService {
         long expiration = jwtService.getTokenExpirationTime(requestAccessToken) - new Date().getTime();
         redisService.setValuesWithTimeout(requestAccessToken, "delete", expiration);
 
-        //소셜 회원 탈퇴 처리
-        //socialUserService.deleteSocialUserWithRedisProcess(user);
+        fcmService.deleteToken(user.getId());     // FCM Token 삭제
     }
 
+    @Transactional
     public void reportUser(Long toUserId) {
-        User toUser = userRepository.findById(toUserId)
+        User toUser = userRepository.findUserByUserId(toUserId)
                 .orElseThrow(() -> new BaseException(FIND_FAIL_USERNAME));
 
         //누적 횟수 3회차, INACTIVE
-        if(toUser.getReported() == 2) {
-            toUser.updateStatus(User.Status.INACTIVE);
+        if (toUser.getReported() == 2) {
+            deleteReportedUser(toUser);
+            return;
         }
 
         //신고 횟수 업데이트
         toUser.updateReported(toUser.getReported() + 1);
         userRepository.save(toUser);
+    }
+
+    @Transactional
+    public void deleteReportedUser(User user) {
+        //1) 가족 일괄 INACTIVE
+        List<Family> familyList = familyRepository.findActiveFamilyByUserId(user);
+        for(Family family : familyList) {
+            family.updateStatus(INACTIVE);
+
+            //1-1) 가족 내 구성원 모두 INACTIVE
+            List<UserFamily> uf = userFamilyRepository.findUserFamilyByFamilyId(family.getFamilyId());
+            for(UserFamily uf1 : uf) {
+                uf1.updateStatus(UserFamily.Status.INACTIVE);
+            }
+        }
+        commonDeleteProcess(user);
     }
 
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -44,6 +44,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import static com.spring.familymoments.config.BaseResponseStatus.*;
 import static com.spring.familymoments.domain.common.BaseEntity.Status.INACTIVE;
@@ -141,13 +142,9 @@ public class UserService {
      * [GET]
      * @return 이미 가입된 아이디면 -> true, 그렇지 않으면 -> false
      */
-    public boolean checkDuplicateIdByStatus(String UserId) {
-        boolean alreadyUser = true;
-        List<User> activeMemberList = userRepository.findUserById(UserId);
-        if(activeMemberList.isEmpty()) {
-            alreadyUser = false;
-        }
-        return alreadyUser;
+    public boolean checkDuplicateIdByStatus(String userId) {
+        Optional<User> activeUser = userRepository.findById(userId);
+        return activeUser.isPresent();
     }
 
 //    /**
@@ -179,12 +176,8 @@ public class UserService {
      * @return
      */
     public boolean checkDuplicateEmailByStatus(String email) {
-        boolean alreadyUser = true;
-        List<User> activeMemberList = userRepository.findUserByEmail(email);
-        if(activeMemberList.isEmpty()) {
-            alreadyUser = false;
-        }
-        return alreadyUser;
+        Optional<User> activeUser = userRepository.findByEmail(email);
+        return activeUser.isPresent();
     }
 
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 자발적 회원 탈퇴 시, 동일 이메일로 재가입 불가 문제
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
1. [fix : 소셜 회원가입 수정 - ACTIVE, response, entity](https://github.com/familymoments/family-moments-BE/pull/189/commits/ac229ddbf116055b0c1c8a8ce54f91db42ab5892)
- SocialInfo entity lazy 방식으로 수정 -> (추후 리펙토링 시, snsId 불필요로 해당 테이블 삭제 예정)
- 소셜 회원가입과 일반 회원가입의 response 동일하게 수정
- 소셜 회원가입 시, active 한 유저만 이미 존재하는 유저로 필터링 

2. [fix : 회원 가입 - ACTIVE 수정](https://github.com/familymoments/family-moments-BE/commit/97255847b7733cd938fe51343d29ee2f16299940)
- 아이디 중복 확인, 이메일 중복 확인, 이름+이메일 확인 -> repository 메소드 active 추가해서 변경함. @sonshn 확인 필요

3. [fix : 회원 탈퇴 (soft delete) 및 set null 설정](https://github.com/familymoments/family-moments-BE/commit/26c05e7b993c4b68e37436349916411d84124d21)
- 기존 soft delete 방식 그대로이지만, 누락된 부분 (socialInfo, alarmSetting, ..) 추가
- fcmToken 관련 controller -> service 단으로 옮김
- set null(알수없음)을 위해 entity에 메소드 추가, field는 nullable하게 변경
- 신고 자동 탈퇴 시, inactive처리 일반 회원가입과 구별 
   - (가족 생성자여도 하위 UserMapping 모두 inactive처리하면서 가족 inactive)
4. [fix : 유저 active 쿼리 추가](https://github.com/familymoments/family-moments-BE/pull/189/commits/d7d920bdf44f9af7a2d77feb2f96cf909a786c80)
- User 관련 active 관련 쿼리를 개선하고 누락된 부분 추가했습니다.
- 급하게 push하다가.. 오타 발생해서 수정했습니다.

### PR 특이 사항

- soft delete로 진행했지만 추후 유저는 hard delete로 변경할 예정.
- entity에서 'nullable = true'와 'socialInfo 수정'으로 데이터 구조 변경되기 때문에 테스트 데이터 날아갈 수 있음.