### PR TITLE
feat: 로그인한 유저의 댓글 좋아요 여부 반환 / 가족 삭제 시 매핑 테이블 INACTIVE

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentController.java
@@ -47,8 +47,9 @@ public class CommentController {
      */
     @GetMapping("")
     @Operation(summary = "특정 게시물의 댓글 목록 조회", description = "특정 게시물의 댓글 목록을 조회합니다.")
-    public BaseResponse<List<GetCommentsRes>> getCommentsByPostId(@RequestParam("postId") Long postId) {
-        List<GetCommentsRes> getCommentsRes = commentService.getCommentsByPostId(postId);
+    public BaseResponse<List<GetCommentsRes>> getCommentsByPostId(@AuthenticationPrincipal @Parameter(hidden = true) User user,
+                                                                  @RequestParam("postId") Long postId) {
+        List<GetCommentsRes> getCommentsRes = commentService.getCommentsByPostId(user, postId);
         return new BaseResponse<>(getCommentsRes);
     }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentService.java
@@ -6,6 +6,7 @@ import com.spring.familymoments.domain.comment.entity.CommentReport;
 import com.spring.familymoments.domain.comment.model.GetCommentsRes;
 import com.spring.familymoments.domain.comment.model.PatchCommentReq;
 import com.spring.familymoments.domain.comment.model.PostCommentReq;
+import com.spring.familymoments.domain.commentLove.CommentLoveRepository;
 import com.spring.familymoments.domain.common.BaseEntity;
 import com.spring.familymoments.domain.post.PostWithUserRepository;
 import com.spring.familymoments.domain.post.entity.Post;
@@ -28,6 +29,7 @@ public class CommentService {
     private final CommentWithUserRepository commentWithUserRepository;
     private final PostWithUserRepository postWithUserRepository;
     private final CommentReportRepository commentReportRepository;
+    private final CommentLoveRepository commentLoveRepository;
 
     // 댓글 생성하기
     @Transactional
@@ -60,8 +62,8 @@ public class CommentService {
     }
 
     // 특정 게시물의 댓글 목록 조회
-    @Transactional
-    public List<GetCommentsRes> getCommentsByPostId(Long postId) throws BaseException{
+    @Transactional(readOnly = true)
+    public List<GetCommentsRes> getCommentsByPostId(User user, Long postId) throws BaseException{
 
         // 게시글 존재 확인
         postWithUserRepository.findById(postId)
@@ -80,7 +82,7 @@ public class CommentService {
                         comment.getWriter().getNickname(),
                         comment.getWriter().getProfileImg(),
                         comment.getContent(),
-                        comment.getCountLove() != 0,
+                        commentLoveRepository.existsByCommentIdAndUserId(comment, user),
                         comment.getCreatedAt()
                 ))
                 .collect(Collectors.toList());

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
@@ -211,6 +211,9 @@ public class FamilyService {
             throw new BaseException(FAILED_USERSS_UNATHORIZED);
         }
 
+        // 가족 - 유저 매핑 확인
+        UserFamily userFamily = userFamilyRepository.findActiveUserFamilyByUserIdAndFamilyId(user, family)
+                .orElseThrow(() -> new BaseException(FIND_FAIL_USER_IN_FAMILY));
 
         // 1. 가족 내 게시글의 댓글 일괄 삭제
         List<Post> postsToDelete = postWithUserRepository.findByFamilyId(family);
@@ -226,6 +229,10 @@ public class FamilyService {
         for (Post post : postsToDelete) {
             post.updateStatus(BaseEntity.Status.INACTIVE);
         }
+
+        // +. 가족-유저 매핑 삭제
+        userFamily.updateStatus(UserFamily.Status.INACTIVE);
+        userFamilyRepository.save(userFamily);
 
         // 3. 가족 삭제
         family.updateStatus(BaseEntity.Status.INACTIVE);


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 로그인한 유저의 댓글 좋아요 여부 반환 / 가족 삭제 시 매핑 테이블 INACTIVE
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 로그인한 유저의 댓글 좋아요 여부 반환
  - 댓글 조회 시 `해당 댓글의 전체 좋아요 여부`를 반환하던 로직에서 `로그인한 유저의 좋아요 여부`를 반환하도록 수정
- 가족 삭제 시 해당 user - family간 `userFamily` 매핑값 INACTIVE 처리