### PR TITLE
fix: 가족 관련 프론트 요청 사항 수정

### DIFF
--- a/.idea/git_toolbox_prj.xml
+++ b/.idea/git_toolbox_prj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxProjectSettings">
+    <option name="commitMessageIssueKeyValidationOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+    <option name="commitMessageValidationEnabledOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+  </component>
+</project>

--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -28,6 +28,8 @@ public enum BaseResponseStatus {
     TOKEN_RESPONSE_ERROR(false, HttpStatus.NOT_FOUND.value(), "값을 불러오는데 실패하였습니다."),
     EXPIRED_JWT(false, HttpStatus.UNAUTHORIZED.value(), "만료된 토큰입니다."),
     TOKEN_REISSUE_ERROR(false, 471, "토큰 발급을 실패했습니다."),
+    FIND_FAIL_DATE(false, HttpStatus.BAD_REQUEST.value(), "날짜가 존재하지 않습니다."),
+    INVALID_TIME_FORMAT(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "날짜 형식이 맞지 않습니다."),
 
 
     /**

--- a/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
@@ -37,9 +37,11 @@ public interface UserFamilyRepository extends JpaRepository<UserFamily, Long> {
             "INNER JOIN UserFamilyMapping m ON u.userId = m.userId " +
             "INNER JOIN Family f ON m.familyId = f.familyId " +
             "WHERE m.status = 'ACTIVE' " +
-            "AND f.familyId = :familyId",
+            "AND f.familyId = :familyId " +
+            "AND u.userId <> :userId",
             nativeQuery = true)
-    List<GetFamilyAllResInterface> findActiveUsersByFamilyId(@Param("familyId") Long familyId);
+    List<GetFamilyAllResInterface> findActiveUsersByFamilyId(@Param("familyId") Long familyId,
+                                                             @Param("userId") Long userId);
 
     boolean existsByUserIdAndFamilyId(User userId, Family familyId);
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyController.java
@@ -194,7 +194,8 @@ public class FamilyController {
             @AuthenticationPrincipal @Parameter(hidden = true) User user,
             @PathVariable Long familyId,
             @RequestParam("uploadCycle") int uploadCycle) {
-        familyService.updateUploadCycle(user, familyId, uploadCycle);
+        Integer cycle = (uploadCycle == 0) ? null : uploadCycle;
+        familyService.updateUploadCycle(user, familyId, cycle);
         return new BaseResponse<>("업로드 주기가 수정되었습니다.");
     }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
@@ -30,12 +30,12 @@ public interface FamilyRepository extends JpaRepository<Family, Long> {
     @Query("SELECT f FROM Family f JOIN f.userFamilies uf WHERE uf.userId = :user AND uf.status = 'ACTIVE' ORDER BY uf.createdAt ASC")
     List<Family> findActiveFamilyByUserId(@Param("user") User user);
 
-    @Query(value = "SELECT DATEDIFF(:today, f.createdAt)  " +
+    @Query(value = "SELECT f.createdAt  " +
             "FROM Family f " +
             "WHERE f.familyId = :familyId " +
             "AND f.status = 'ACTIVE' ",
             nativeQuery = true)
-    String findCreatedAtNicknameById(@Param("familyId") Long familyId, @Param("today") LocalDateTime today);
+    String findCreatedAtNicknameById(@Param("familyId") Long familyId);
 
     @Query(value = "SELECT u.id, u.nickname, f.familyName  " +
             "FROM Family f " +

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
@@ -35,7 +35,6 @@ public class FamilyService {
     private final CommentWithUserRepository commentWithUserRepository;
 
     private static final int MAX_FAMILY_COUNT = 5;
-    private static final String INVITE_LINK = "https://family-moments.com/invite/";
 
     // 가족 생성하기
     @Transactional
@@ -44,14 +43,13 @@ public class FamilyService {
 
         // 초대 링크 생성
         String invitationCode = UUID.randomUUID().toString();
-        String inviteLink = INVITE_LINK + invitationCode;
 
         // 가족 입력 객체 생성
         Family family = Family.builder()
                 .owner(owner)
                 .familyName(postFamilyReq.getFamilyName())
                 .uploadCycle(postFamilyReq.getUploadCycle())
-                .inviteCode(inviteLink)
+                .inviteCode(invitationCode)
                 .representImg(fileUrl)
                 .build();
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
@@ -108,19 +108,7 @@ public class FamilyService {
         familyRepository.findById(familyId)
                 .orElseThrow(() -> new BaseException(FIND_FAIL_FAMILY));
 
-        String userId = user.getId();
-        List<GetFamilyAllResInterface> members = userFamilyRepository.findActiveUsersByFamilyId(familyId);
-
-        // 요청한 본인은 제외하고 반환
-        Iterator<GetFamilyAllResInterface> iterator = members.iterator();
-        while (iterator.hasNext()) {
-            if (iterator.next().getId().equals(userId)) {
-                iterator.remove();
-                break;
-            }
-        }
-
-        return members;
+        return userFamilyRepository.findActiveUsersByFamilyId(familyId, user.getUserId());
     }
 
     // 초대코드로 가족 조회

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
@@ -12,6 +12,7 @@ import com.spring.familymoments.domain.post.PostWithUserRepository;
 import com.spring.familymoments.domain.post.entity.Post;
 import com.spring.familymoments.domain.user.UserRepository;
 import com.spring.familymoments.domain.user.entity.User;
+import com.spring.familymoments.utils.CustomDateTimeUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -94,13 +95,11 @@ public class FamilyService {
     // 닉네임 및 가족 생성일 조회
     @Transactional
     public GetFamilyCreatedNicknameRes getFamilyCreatedNickname(User user, Long familyId) {
-        LocalDateTime today = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
-        String dday = familyRepository.findCreatedAtNicknameById(familyId, today);
-        if (dday == null) {
-            throw new BaseException(FIND_FAIL_FAMILY_CREATION_DATE);
-        }
 
-        return new GetFamilyCreatedNicknameRes(user.getNickname(), dday);
+        String createdAtStr = familyRepository.findCreatedAtNicknameById(familyId);
+        return new GetFamilyCreatedNicknameRes(
+                user.getNickname(),
+                CustomDateTimeUtils.format_yyyyMMddHHmmss(createdAtStr));
     }
 
     // 가족원 전체 조회

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyService.java
@@ -181,7 +181,7 @@ public class FamilyService {
 
     // 업로드 주기 수정
     @Transactional
-    public void updateUploadCycle(User user, Long familyId, int uploadCycle) {
+    public void updateUploadCycle(User user, Long familyId, Integer uploadCycle) {
         Family family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new BaseException(FIND_FAIL_FAMILY));
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/entity/Family.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/entity/Family.java
@@ -41,7 +41,7 @@ public class Family extends BaseEntity {
     private String familyName;
 
     @Column(columnDefinition = "int unsigned")
-    private int uploadCycle;
+    private Integer uploadCycle;
 
     @Column(columnDefinition = "TEXT", nullable = false)
     private String inviteCode;
@@ -97,7 +97,7 @@ public class Family extends BaseEntity {
     /**
      * 가족 업로드 주기 수정 API 관련 메소드
      */
-    public void updateUploadCycle(int uploadCycle) {
+    public void updateUploadCycle(Integer uploadCycle) {
         this.uploadCycle = uploadCycle;
     }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/model/GetFamilyCreatedNicknameRes.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/model/GetFamilyCreatedNicknameRes.java
@@ -15,7 +15,7 @@ import lombok.Setter;
 public class GetFamilyCreatedNicknameRes {
     @Schema(description = "유저 닉네임" , example = "몰리")
     private String nickname;
-    @Schema(description = "가족 생성일 디데이" , example = "10")
-    private String dday;
+    @Schema(description = "가족 생성일" , example = "2023-08-01 00:47:39")
+    private String createdAt;
 
 }

--- a/family-moments/src/main/java/com/spring/familymoments/utils/CustomDateTimeUtils.java
+++ b/family-moments/src/main/java/com/spring/familymoments/utils/CustomDateTimeUtils.java
@@ -1,0 +1,50 @@
+package com.spring.familymoments.utils;
+
+import com.spring.familymoments.config.BaseException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import static com.spring.familymoments.config.BaseResponseStatus.FIND_FAIL_DATE;
+import static com.spring.familymoments.config.BaseResponseStatus.INVALID_TIME_FORMAT;
+
+public class CustomDateTimeUtils {
+
+    // 포맷터 정의
+    private static final DateTimeFormatter FORMATTER_INPUT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+    private static final DateTimeFormatter FORMATTER_yyyyMMddHHmmss = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final DateTimeFormatter FORMATTER_yyyyMMddHHmm = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private static final DateTimeFormatter FORMATTER_yyyyMMdd = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    private CustomDateTimeUtils() {
+        // 인스턴스 생성 방지
+    }
+
+    // 공통 포맷팅 메서드
+    private static String formatWithFormatter(String dateTimeStr, DateTimeFormatter outputFormatter) {
+        if (dateTimeStr == null) {
+            throw new BaseException(FIND_FAIL_DATE);
+        }
+        try {
+            LocalDateTime dateTime = LocalDateTime.parse(dateTimeStr, FORMATTER_INPUT);
+            return dateTime.format(outputFormatter);
+        } catch (DateTimeParseException e) {
+            throw new BaseException(INVALID_TIME_FORMAT);
+        }
+    }
+
+    // 문자열 -> yyyy-MM-dd HH:mm:ss
+    public static String format_yyyyMMddHHmmss(String dateTimeStr) {
+        return formatWithFormatter(dateTimeStr, FORMATTER_yyyyMMddHHmmss);
+    }
+
+    // 문자열 -> yyyy-MM-dd HH:mm
+    public static String format_yyyyMMddHHmm(String dateTimeStr) {
+        return formatWithFormatter(dateTimeStr, FORMATTER_yyyyMMddHHmm);
+    }
+
+    // 문자열 -> yyyy-MM-dd
+    public static String format_yyyyMMdd(String dateTimeStr) {
+        return formatWithFormatter(dateTimeStr, FORMATTER_yyyyMMdd);
+    }
+}


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가
1.  (메인)닉네임 및 가족 생성일 조회 API - d-day 대신 UTC 시간으로 반환
2. 가족원 전체 조회 - 본인 포함/미포함 옵션 추가
3. 가족 생성 - 초대코드 UUID로만 구성
4. 가족 업로드 주기 수정 - 0입력하면 null로 변환
- [ ] 버그 수정 :
- [ ] 리펙토링 : 
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
위 기능 순서대로
1.  프론트에서 로컬 타임으로 변경하기로 해서 UTC로 반환하도록 합니다.
2. 서비스 로직에서 처리하는 코드를 DB단으로 이동했습니다.
3. 링크 형식이 사용자에게 혼란을 가져올 수 있어 변경합니다.
4. 수정 시, url에 null을 포함할 수 없어 0으로 입력받고 서버 내부에서 변경하도록 했습니다.

### 작업 후 기대 동작(스크린샷)
1.  (메인)닉네임 및 가족 생성일 조회 API - d-day 대신 UTC 시간으로 반환
![image](https://github.com/user-attachments/assets/a5fdcfaf-bb60-484c-872f-2a32adfbda98)


2. 가족원 전체 조회 - 본인 포함/미포함 옵션 추가
![image](https://github.com/user-attachments/assets/2115b2e5-7b00-4397-8cf6-902c9b80d1a6)

3. 가족 생성 - 초대코드 UUID로만 구성
![image](https://github.com/user-attachments/assets/6267ad43-1259-453f-94d7-e170e330f799)

4. 가족 업로드 주기 수정 - 0입력하면 null로 변환
![image](https://github.com/user-attachments/assets/dace77fb-ed0f-4cd9-9bef-083a9b9fdc42)
![image](https://github.com/user-attachments/assets/092b8ecc-8346-4d9d-9641-255666508975)

