### PR TITLE
fix: 초대코드로 가족 리스트 조회 ACTIVE만 조회하도록 보완

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/FamilyRepository.java
@@ -1,9 +1,7 @@
 package com.spring.familymoments.domain.family;
 
 import com.spring.familymoments.domain.family.entity.Family;
-import com.spring.familymoments.domain.family.model.GetFamilyCreatedNicknameRes;
 import com.spring.familymoments.domain.user.entity.User;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,6 +14,7 @@ import java.util.Optional;
 public interface FamilyRepository extends JpaRepository<Family, Long> {
     Optional<Family> findById(Long familyId);
 
+    @Query("SELECT f FROM Family f WHERE f.inviteCode = :inviteCode AND f.status = 'ACTIVE' ")
     Optional<Family> findByInviteCode(String inviteCode);
 
     //회원 탈퇴 시, 가족 생성자 권한 여부를 확인하기 위한 조회


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 초대코드로 가족 리스트 조회 ACTIVE만 조회하도록 보완
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
- INACTIVE 처리된 family가 조회되는 오류 fix