### PR TITLE
fix: Post 삭제 API 수정

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -176,7 +176,9 @@ public class PostService {
     @Transactional
     public void deletePost(User user, long postId) {
         // 삭제할 Post 정보 불러오기
-        Post deletedPost = postRepository.findById(postId).orElseThrow(() -> new BaseException(minnie_POSTS_NON_EXISTS_POST));
+        Post deletedPost = postRepository.findById(postId)
+                .orElseThrow(() -> new BaseException(minnie_POSTS_NON_EXISTS_POST));
+
         // 수정할 Post Document 정보 불러오기
         PostDocument deletedPostDocument = postDocumentRepository.findPostDocumentByEntityId(postId)
                 .orElseThrow(() -> new BaseException(minnie_POSTS_NON_EXISTS_POST));
@@ -189,7 +191,7 @@ public class PostService {
             throw new BaseException(minnie_POSTS_DELETE_INVALID_USER);
         }
 
-        deletedPost.delete();
+        postRepository.delete(deletedPost);
         postDocumentRepository.delete(deletedPostDocument);
     }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/Post.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/Post.java
@@ -54,9 +54,6 @@ public class Post extends BaseEntity {
         this.countLove = countLove - 1;
     }
 
-    public void delete() {
-        this.status = Status.INACTIVE;
-    }
     /**
      * 가족 삭제 API 관련 메소드
      */


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [X] 버그 수정 : `deletePost` 함수는 완전 삭제만 하도록 수정
- [X] 리펙토링 : `Post` 엔티티 중복 코드 삭제
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 기존 `deletePost` 함수는 완전 삭제와 INACTIVE 처리가 혼용되어 신고 및 탈퇴 후 일부 상황에서 조회가 되지 않던 오류가 있었습니다 (@zzo3ozz)
- 신고 및 탈퇴 코드 확인 결과 INACTIVE 처리는 해당 기능을 수행하는 함수에서 처리하는 것이 맞다고 생각하여 기존 `deletePost`함수는 완전 삭제만 하도록 수정했습니다. (@spacewalk00)

### 작업 내역

- Post 엔티티의 `delete` 함수 삭제 

### 작업 후 기대 동작(스크린샷)

- 기존과 같습니다!
