### PR TITLE
fix: 가족 정보 조회 시, uploadCycle이 null인 경우 에러 보완

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/family/entity/Family.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/family/entity/Family.java
@@ -72,7 +72,7 @@ public class Family extends BaseEntity {
                 .familyId(familyId)
                 .ownerId(owner.getUserId())
                 .familyName(familyName)
-                .uploadCycle(uploadCycle)
+                .uploadCycle(uploadCycle == null ? 0 : uploadCycle)
                 .inviteCode(inviteCode)
                 .representImg(representImg)
                 .build();


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 가족 정보 조회 시, uploadCycle이 null인 경우 에러 보완
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 


### 작업 내역

- uploadCycle이 null인 경우 0으로 반환하도록 수정