### PR TITLE
fix : 유저 완전 삭제, 신고 기능 수정

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
+++ b/family-moments/src/main/java/com/spring/familymoments/config/BaseResponseStatus.java
@@ -66,6 +66,7 @@ public enum BaseResponseStatus {
     FIND_FAIL_POST(false, HttpStatus.BAD_REQUEST.value(), "비활성화된 게시글입니다."),
     NOT_EQUAL_NEW_PASSWORD(false, HttpStatus.BAD_REQUEST.value(), "입력한 비밀번호와 일치하지 않습니다."),
     EXPIRED_AT_ERROR(false, 471, "탈퇴를 위해 가입했던 소셜 계정으로 재로그인 하세요"),
+    FAILED_USER_REPORT(false, HttpStatus.BAD_REQUEST.value(), "본인을 신고할 수 없습니다."),
     /**
      * 500 : Database, Server 오류
      */

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentReportRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentReportRepository.java
@@ -1,11 +1,11 @@
 package com.spring.familymoments.domain.comment;
 
+import com.spring.familymoments.domain.comment.entity.Comment;
 import com.spring.familymoments.domain.comment.entity.CommentReport;
-import com.spring.familymoments.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface CommentReportRepository extends JpaRepository<CommentReport, Long>  {
-    List<CommentReport> findCommentReportByUser(User user);
+    List<CommentReport> findCommentReportByComment(Comment comment);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentService.java
@@ -134,9 +134,9 @@ public class CommentService {
         Comment comment = commentWithUserRepository.findById(commentId)
                 .orElseThrow(() -> new BaseException(FIND_FAIL_COMMENT));
 
-        //누적 횟수 3회차, INACTIVE
+        //누적 횟수 3회차
         if(comment.getReported() == 2) {
-            comment.updateStatus(BaseEntity.Status.INACTIVE);
+            commentWithUserRepository.delete(comment);
         }
 
         //신고 사유 저장
@@ -144,8 +144,7 @@ public class CommentService {
                 fromUser,
                 comment,
                 ReportReason.getEnumTypeFromStringReportReason(contentReportReq.getReportReason()),
-                contentReportReq.getDetails(),
-                comment.getWriter().getEmail()
+                contentReportReq.getDetails()
         );
         commentReportRepository.save(reportedComment);
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentService.java
@@ -134,11 +134,6 @@ public class CommentService {
         Comment comment = commentWithUserRepository.findById(commentId)
                 .orElseThrow(() -> new BaseException(FIND_FAIL_COMMENT));
 
-        //누적 횟수 3회차
-        if(comment.getReported() == 2) {
-            commentWithUserRepository.delete(comment);
-        }
-
         //신고 사유 저장
         CommentReport reportedComment = CommentReport.createCommentReport(
                 fromUser,
@@ -148,10 +143,15 @@ public class CommentService {
         );
         commentReportRepository.save(reportedComment);
 
-        //신고 횟수 업데이트
-        comment.updateReported(comment.getReported() + 1);
-        commentWithUserRepository.save(comment);
-    }
+        //누적 횟수 3회차일 때 댓글 삭제
+        if(comment.getReported() == 2) {
+            commentWithUserRepository.delete(comment);
+        } else {
+            //신고 횟수 업데이트
+            comment.updateReported(comment.getReported() + 1);
+            commentWithUserRepository.save(comment);
+        }
 
+    }
 
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/CommentService.java
@@ -142,7 +142,8 @@ public class CommentService {
                 fromUser,
                 comment,
                 ReportReason.getEnumTypeFromStringReportReason(contentReportReq.getReportReason()),
-                contentReportReq.getDetails()
+                contentReportReq.getDetails(),
+                comment.getWriter().getEmail()
         );
         commentReportRepository.save(reportedComment);
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/entity/CommentReport.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/entity/CommentReport.java
@@ -23,11 +23,11 @@ public class CommentReport extends BaseEntity {
     private Long commentReportId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId")
+    @JoinColumn(name = "userId", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "commentId", nullable = false)
+    @JoinColumn(name = "commentId")
     private Comment comment;
 
     @Enumerated(EnumType.STRING)
@@ -36,20 +36,21 @@ public class CommentReport extends BaseEntity {
 
     private String details;
 
-    public static CommentReport createCommentReport(User fromUser, Comment reportedComment, ReportReason reportReason, String details) {
+    @Column(nullable = false, length = 45)
+    private String offenderEmail;
+
+    public static CommentReport createCommentReport(User fromUser, Comment reportedComment, ReportReason reportReason, String details, String offenderEmail) {
         return CommentReport.builder()
                 .user(fromUser)
                 .comment(reportedComment)
                 .reportReason(reportReason)
                 .details(details)
+                .offenderEmail(offenderEmail)
                 .build();
     }
 
     /***
-     * SET NULL -> 추후 변경 예정
+     * 댓글 신고 NULL 처리
      */
-    public void updateUser() {
-        this.user = null;
-    }
-
+    public void updateComment() {this.comment = null;}
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/comment/entity/CommentReport.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/comment/entity/CommentReport.java
@@ -27,7 +27,7 @@ public class CommentReport extends BaseEntity {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "commentId")
+    @JoinColumn(name = "commentId", nullable = false)
     private Comment comment;
 
     @Enumerated(EnumType.STRING)
@@ -36,21 +36,13 @@ public class CommentReport extends BaseEntity {
 
     private String details;
 
-    @Column(nullable = false, length = 45)
-    private String offenderEmail;
-
-    public static CommentReport createCommentReport(User fromUser, Comment reportedComment, ReportReason reportReason, String details, String offenderEmail) {
+    public static CommentReport createCommentReport(User fromUser, Comment reportedComment, ReportReason reportReason, String details) {
         return CommentReport.builder()
                 .user(fromUser)
                 .comment(reportedComment)
                 .reportReason(reportReason)
                 .details(details)
-                .offenderEmail(offenderEmail)
                 .build();
     }
 
-    /***
-     * 댓글 신고 NULL 처리
-     */
-    public void updateComment() {this.comment = null;}
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/common/UserFamilyRepository.java
@@ -26,6 +26,9 @@ public interface UserFamilyRepository extends JpaRepository<UserFamily, Long> {
     //회원 탈퇴 시, UserFamily 매핑 테이블 해제를 위한 조회
     @Query("SELECT uf FROM UserFamily uf WHERE uf.userId.userId = :userId")
     List<UserFamily> findUserFamilyByUserId(@Param("userId") Long userId);
+    @Query("SELECT uf FROM UserFamily uf WHERE uf.inviteUserId.userId = :userId")
+    List<UserFamily> findUserFamilyByInviteUserId(@Param("userId") Long userId);
+
     @Query("SELECT uf FROM UserFamily uf WHERE uf.familyId.familyId = :familyId AND uf.status = 'ACTIVE' ")
     List<UserFamily> findUserFamilyByFamilyId(@Param("familyId") Long familyId);
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/common/entity/UserFamily.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/common/entity/UserFamily.java
@@ -38,7 +38,7 @@ public class UserFamily extends BaseTime {
     protected Status status = Status.DEACCEPT;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "inviteUserId", nullable = false)
+    @JoinColumn(name = "inviteUserId")
     private User inviteUserId;
 
     public enum Status {
@@ -47,5 +47,9 @@ public class UserFamily extends BaseTime {
 
     public void updateStatus(Status status) {
         this.status = status;
+    }
+
+    public void updateInviteUserId() {
+        this.inviteUserId = null;
     }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostReportRepository.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostReportRepository.java
@@ -1,11 +1,11 @@
 package com.spring.familymoments.domain.post;
 
+import com.spring.familymoments.domain.post.entity.Post;
 import com.spring.familymoments.domain.post.entity.PostReport;
-import com.spring.familymoments.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface PostReportRepository extends JpaRepository<PostReport, Long> {
-    List<PostReport> findPostReportByUser(User user);
+    List<PostReport> findPostReportByPost(Post post);
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -511,7 +511,8 @@ public class PostService {
                fromUser,
                post,
                ReportReason.getEnumTypeFromStringReportReason(contentReportReq.getReportReason()),
-               contentReportReq.getDetails()
+               contentReportReq.getDetails(),
+               post.getWriter().getEmail()
        );
        postReportRepository.save(reportedPost);
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -501,23 +501,24 @@ public class PostService {
        Post post = postRepository.findById(postId)
                .orElseThrow(() -> new BaseException(minnie_POSTS_NON_EXISTS_POST));
 
-       //누적 횟수 3회차
-       if(post.getReported() == 2) {
-           postRepository.delete(post);
-       }
-
        //신고 사유 저장
        PostReport reportedPost = PostReport.createPostReport(
-               fromUser,
-               post,
-               ReportReason.getEnumTypeFromStringReportReason(contentReportReq.getReportReason()),
-               contentReportReq.getDetails()
+                fromUser,
+                post,
+                ReportReason.getEnumTypeFromStringReportReason(contentReportReq.getReportReason()),
+                contentReportReq.getDetails()
        );
        postReportRepository.save(reportedPost);
 
-       //신고 횟수 업데이트
-       post.updateReported(post.getReported() + 1);
-       postRepository.save(post);
+       //누적 횟수 3회차일 때 게시물 삭제
+       if(post.getReported() == 2) {
+           postRepository.delete(post);
+       } else {
+           //신고 횟수 업데이트
+           post.updateReported(post.getReported() + 1);
+           postRepository.save(post);
+       }
+
     }
 
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -501,9 +501,9 @@ public class PostService {
        Post post = postRepository.findById(postId)
                .orElseThrow(() -> new BaseException(minnie_POSTS_NON_EXISTS_POST));
 
-       //누적 횟수 3회차, INACTIVE
+       //누적 횟수 3회차
        if(post.getReported() == 2) {
-           post.updateStatus(BaseEntity.Status.INACTIVE);
+           postRepository.delete(post);
        }
 
        //신고 사유 저장
@@ -511,8 +511,7 @@ public class PostService {
                fromUser,
                post,
                ReportReason.getEnumTypeFromStringReportReason(contentReportReq.getReportReason()),
-               contentReportReq.getDetails(),
-               post.getWriter().getEmail()
+               contentReportReq.getDetails()
        );
        postReportRepository.save(reportedPost);
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/PostReport.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/PostReport.java
@@ -24,7 +24,7 @@ public class PostReport extends BaseEntity {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "postId")
+    @JoinColumn(name = "postId", nullable = false)
     private Post post;
 
     @Enumerated(EnumType.STRING)
@@ -33,21 +33,13 @@ public class PostReport extends BaseEntity {
 
     private String details;
 
-    @Column(nullable = false, length = 45)
-    private String offenderEmail;
-
-    public static PostReport createPostReport(User fromUser, Post reportedPost, ReportReason reportReason, String details, String offenderEmail) {
+    public static PostReport createPostReport(User fromUser, Post reportedPost, ReportReason reportReason, String details) {
         return PostReport.builder()
                 .user(fromUser)
                 .post(reportedPost)
                 .reportReason(reportReason)
                 .details(details)
-                .offenderEmail(offenderEmail)
                 .build();
     }
 
-    /**
-     * 게시글 신고 null 처리
-     */
-    public void updatePost() { this.post = null; }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/PostReport.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/entity/PostReport.java
@@ -20,11 +20,11 @@ public class PostReport extends BaseEntity {
     private Long postReportId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId")
+    @JoinColumn(name = "userId", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "postId", nullable = false)
+    @JoinColumn(name = "postId")
     private Post post;
 
     @Enumerated(EnumType.STRING)
@@ -33,20 +33,21 @@ public class PostReport extends BaseEntity {
 
     private String details;
 
-    public static PostReport createPostReport(User fromUser, Post reportedPost, ReportReason reportReason, String details) {
+    @Column(nullable = false, length = 45)
+    private String offenderEmail;
+
+    public static PostReport createPostReport(User fromUser, Post reportedPost, ReportReason reportReason, String details, String offenderEmail) {
         return PostReport.builder()
                 .user(fromUser)
                 .post(reportedPost)
                 .reportReason(reportReason)
                 .details(details)
+                .offenderEmail(offenderEmail)
                 .build();
     }
 
     /**
      * 게시글 신고 null 처리
      */
-    public void updateUser() {
-        this.user = null;
-    }
-
+    public void updatePost() { this.post = null; }
 }

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserController.java
@@ -437,9 +437,9 @@ public class UserController {
      * 유저 신고 API
      * [POST] /users/report
      */
-    @PostMapping("/users/report/{userId}")
-    public BaseResponse<String> reportUser(@PathVariable Long userId) {
-        userService.reportUser(userId);
+    @PostMapping("/users/report")
+    public BaseResponse<String> reportUser(@AuthenticationPrincipal @Parameter(hidden = true) User fromUser, @RequestBody GetUserIdReq req) {
+        userService.reportUser(fromUser, req.getUserId());
         return new BaseResponse<>("유저를 신고했습니다.");
     }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/user/UserService.java
@@ -413,9 +413,14 @@ public class UserService {
     }
 
     @Transactional
-    public void reportUser(Long toUserId) {
-        User toUser = userRepository.findUserByUserId(toUserId)
+    public void reportUser(User fromUser, String toUserId) {
+        User toUser = userRepository.findById(toUserId)
                 .orElseThrow(() -> new BaseException(FIND_FAIL_USERNAME));
+
+        //본인 신고 불가
+        if(fromUser.getId().equals(toUserId)) {
+            throw new BaseException(FAILED_USER_REPORT);
+        }
 
         //누적 횟수 3회차, INACTIVE
         if (toUser.getReported() == 2) {


### PR DESCRIPTION
### 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 유저 완전 삭제, 유저 신고
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

1. hard delete
   - mysql cascade 걸어둬서 유저 탈퇴 시 관련 정보 모두 삭제
   => set null fk db 변경은 배포 이후 진행 (현재는 method로 null 처리 중.)
   
2. Xreport 관련 테이블(CommentReport, PostReport) : offenderemail 칼럼 추가, 컨텐츠(comment/post) fk nullable = trueX
   - 기존 : 탈퇴한 사용자가 신고를 했던 내역을 남기는 것
   - 변경 : (원래 기획대로) 탈퇴한 사용자가 **신고 받았던 내역** 남기는 것
   -> 참고할점 : 탈퇴한 사용자가 신고한 내역은 cascade 영향으로 전부 삭제될 예정. (남기는 게 의미없다고 판단했음) 
   => xxxxxxxxx (회의 통해 삭제)
   
3. 유저 신고
   - 본인 신고 예외처리 추가
   - 유저번호가 아닌 유저아이디로 신고
   -> 참고할 점 : 유저 신고 3번 이상시 자동 탈퇴인데, 이 해당 유저가 가족 생성자라도 예외없이 삭제되어 가족삭제됨.(가족 내 활동 내역 전부 삭제됨)
