### PR TITLE
feat: S3 버켓에 업로드된 이미지 객체 삭제

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -189,17 +189,18 @@ public class PostService {
         for(String url: deletedPostDocument.getUrls()) {
             int indexOfThumbnailPrefix = url.indexOf(THUMBNAIL_PREFIX);
 
-            // 분리된 문자열에서 파일 이름 추출 후 양쪽 폴더에서 이미지 객체 삭제
-            if (indexOfThumbnailPrefix != -1) {
-                String thumbnail = url.substring(indexOfThumbnailPrefix);
-                String fileName = thumbnail.substring(thumbnail.lastIndexOf('/') + 1);
-                String origin = ORIGIN_PREFIX + fileName;
-
-                awsS3Service.deleteImage(thumbnail);
-                awsS3Service.deleteImage(origin);
-            } else {
+            // 'THUMBNAIL_PREFIX'가 URL 문자열에 없는 경우
+            if (indexOfThumbnailPrefix == -1) {
                 throw new BaseException(DELETE_FAIL_S3);
             }
+
+            // 분리된 문자열에서 파일 이름 추출 후 양쪽 폴더에서 이미지 객체 삭제
+            String thumbnail = url.substring(indexOfThumbnailPrefix);
+            String fileName = thumbnail.substring(thumbnail.lastIndexOf('/') + 1);
+            String origin = ORIGIN_PREFIX + fileName;
+
+            awsS3Service.deleteImage(thumbnail);
+            awsS3Service.deleteImage(origin);
         }
 
         postRepository.delete(deletedPost);


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : S3 버켓 내 이미지 객체 삭제 로직 추가
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
- S3 버켓 내 이미지 객체 삭제 로직을 추가했습니다. 순서는 다음과 같습니다.
1. 삭제할 게시물에 포함된 이미지 파일들의 URL 문자열을 차례대로 불러옴
2. 불러온 문자열에서 `THUMBNAIL_PREFIX`를 바탕으로 파일명만 추출
3. 추출된 파일명에 `ORIGIN_PREFIX`를 이어 붙임
4. 기존의 `deleteImage` 함수를 두 번 호출하여, 원본 이미지와 썸네일 이미지 모두 삭제 진행
- 위 과정을 거쳐 이미지 객체를 삭제하면, S3 비용을 많이 줄일 수 있을 것 같습니다! 😄 
- [AWS 공식 문서](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html)에 따르면, S3 객체들 간에는 **파일 시스템 같은 계층 구조가 없고, 단지 그룹으로 쉽게 분류하기 위해 '폴더' 개념을 제공**한다고 합니다.
- 따라서, **`/thumbnail`로 접근하지 않고, `thumbnail/`로 접근**해서 구현할 수 있었습니다,
- 또한, 파일명을 추출할 때도 앞에 `/`를 붙이면 안됩니다

### 작업 내역
- S3 버켓 내 이미지 객체 삭제 로직 추가

### 작업 후 기대 동작(스크린샷)
- 게시물 삭제 API를 호출하면, 게시물에 포함된 이미지 객체들이 S3 Bucket에 삭제됩니다.
- `thumbnails`,` fm-origin` 양쪽 모두에서 삭제됩니다!

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
- #186 에서 힌트를 얻었습니다 😄
- 비슷한 방법으로 프로필 이미지의 경우에도 사용해도 될 것 같습니다
- 게시물 수정(**연동 후**)의 경우에도 사용해도 될 것 같습니다