### PR TITLE
fix: 게시물 수정 API

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostController.java
@@ -77,15 +77,15 @@ public class PostController {
     public BaseResponse<SinglePostRes> editPost(@AuthenticationPrincipal @Parameter(hidden = true) User user,
                                                 @PathVariable long postId,
                                                 @RequestPart(name = "postInfo", required = false) PostEditInfoReq postEditInfoReq,
-                                                @RequestPart("imgs") List<MultipartFile> imgs) {
-        if(postEditInfoReq == null && imgs.isEmpty()) {
+                                                @RequestPart(name = "newImgs", required = false) List<MultipartFile> newImgs) {
+        if(postEditInfoReq == null) {
             return new BaseResponse<>(minnie_POSTS_EMPTY_UPDATE);
         }
 
         PostEditReq postEditReq = PostEditReq.builder()
-                .urls(postEditInfoReq != null ? postEditInfoReq.getUrls() : null)
-                .imgs(imgs)
-                .content((postEditInfoReq != null) ? postEditInfoReq.getContent() : null)
+                .urls(postEditInfoReq.getUrls())
+                .newImgs(newImgs)
+                .content(postEditInfoReq.getContent())
                 .build();
 
         SinglePostRes singlePostRes = postService.editPost(user, postId, postEditReq);

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -117,21 +117,23 @@ public class PostService {
             throw new BaseException(minnie_POSTS_EDIT_INVALID_USER);
         }
 
-        if(postEditReq.getImgs().size() > MAX_IMAGE_SIZE) {
+        // 기존 이미지
+        List<String> originImgs = postEditReq.getUrls();
+        // 새로운 이미지: 이미지를 추가하지 않고도 수정이 되도록 허용
+        List<MultipartFile> newFiles = postEditReq.getNewImgs();
+        List<String> newImgs = new ArrayList<>();
+
+        if(originImgs.size() + postEditReq.getNewImgs().size() > MAX_IMAGE_SIZE) {
             throw new BaseException(minnie_POSTS_FULL_IMAGE);
         }
 
-        // 기존 이미지
-        List<String> originImgs = postEditReq.getUrls();
-        // 새로운 이미지
-        List<MultipartFile> newFiles = postEditReq.getImgs();
-        List<String> newImgs = new ArrayList<>();
-
-        // image 업로드 (S3)
+        // S3에 새로운 이미지 업로드
         for(MultipartFile img : newFiles) {
-            String url = null;
-            url = awsS3Service.uploadImage(img);
-            newImgs.add(url);
+            if(img.getSize() > 0) {
+                String url = null;
+                url = awsS3Service.uploadImage(img);
+                newImgs.add(url);
+            }
         }
 
         // 기존 이미지와 새로운 이미지를 하나의 필드로 병합

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/model/PostEditReq.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/model/PostEditReq.java
@@ -18,7 +18,7 @@ public class PostEditReq {
     @Schema(description = "바꾸지 않을(기존) 사진의 url 문자열 리스트 (','로 구분)", example = "[https://url.com/img1.png, https://url.com/img2.png]")
     private List<String> urls;
     @Schema(description = "새로 업로드 할 이미지", example = "[img1.png, img2.png]")
-    private List<MultipartFile> imgs;
+    private List<MultipartFile> newImgs;
     @Schema(description = "수정한 게시물의 본문", example = "오늘은 날씨가 좋아요")
     private String content;
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 새로운 이미지를 추가하지 않고도 수정이 가능하도록 했습니다
- [x] 버그 수정 : 이미지의 개수 관련 예외 처리를 수정했습니다 
- [x] 리펙토링 : DTO와 Request의 `imgs` 필드명을 `newImgs`로 변경했습니다
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
- 이미지는 그대로 두고, 내용만 변경하는 경우를 고려해서 새로운 이미지를 추가하지 않고도 수정이 가능하도록 했습니다
- 의미를 명확하게 하기 위해 DTO와 Request의 `imgs` 필드명을 `newImgs`로 변경했습니다

### 작업 내역
- 이미지는 그대로 두고, 내용만 변경하는 경우를 고려해서 새로운 이미지를 추가하지 않고도 수정이 가능하도록 했습니다
- 의미를 명확하게 하기 위해 DTO와 Request의 `imgs` 필드명을 `newImgs`로 변경했습니다

### 작업 후 기대 동작(스크린샷)
- 이전과 같습니다

### PR 특이 사항
- 새로운 이미지를 추가하지 않고도 수정이 가능하도록 했습니다
- 이외는 #212 와 같습니다 
