### PR TITLE
fix: 게시물 수정 API

### DIFF
--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -123,16 +123,18 @@ public class PostService {
         List<MultipartFile> newFiles = postEditReq.getNewImgs();
         List<String> newImgs = new ArrayList<>();
 
-        if(originImgs.size() + postEditReq.getNewImgs().size() > MAX_IMAGE_SIZE) {
-            throw new BaseException(minnie_POSTS_FULL_IMAGE);
-        }
+        if(postEditReq.getNewImgs() != null) {
+            if (originImgs.size() + postEditReq.getNewImgs().size() > MAX_IMAGE_SIZE) {
+                throw new BaseException(minnie_POSTS_FULL_IMAGE);
+            }
 
-        // S3에 새로운 이미지 업로드
-        for(MultipartFile img : newFiles) {
-            if(img.getSize() > 0) {
-                String url = null;
-                url = awsS3Service.uploadImage(img);
-                newImgs.add(url);
+            // S3에 새로운 이미지 업로드
+            for(MultipartFile img : newFiles) {
+                if(img.getSize() > 0) {
+                    String url = null;
+                    url = awsS3Service.uploadImage(img);
+                    newImgs.add(url);
+                }
             }
         }
 

--- a/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
+++ b/family-moments/src/main/java/com/spring/familymoments/domain/post/PostService.java
@@ -123,6 +123,7 @@ public class PostService {
         List<MultipartFile> newFiles = postEditReq.getNewImgs();
         List<String> newImgs = new ArrayList<>();
 
+        // 새로운 이미지를 추가하지 않고도 수정이 되도록 허용
         if(postEditReq.getNewImgs() != null) {
             if (originImgs.size() + postEditReq.getNewImgs().size() > MAX_IMAGE_SIZE) {
                 throw new BaseException(minnie_POSTS_FULL_IMAGE);


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)
- [ ] 신규 기능 추가 :
- [X] 버그 수정 : 새로운 이미지 필드(`newImgs`)가 null일 경우 예외 처리 추가
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
- 새로운 이미지 필드(`newImgs`)가 null일 경우 예외 처리) 추가
- 안드로이드 환경에서 테스트를 진행할 때 필드에 아무런 값도 넘어오지 않는 경우, 필드 자체가 null 처리가 되기 때문에 발생하는 오류였습니다!
- 해당 오류는 Spring에서 제공하는 `@Nullable`이나, `required=false`로도 처리할 수 없었기 때문에 if문으로 예외를 잡도록 했습니다

### 작업 내역
- 새로운 이미지 필드(`newImgs`)가 null일 경우 예외 처리) 추가
- if문을 이용하여 필드가 null일 경우 예외 처리를 했습니다.

### 작업 후 기대 동작(스크린샷)
- 아래 경우에도 API가 제대로 실행됩니다
![image](https://github.com/user-attachments/assets/a3b9a32a-0564-4abc-9413-5f4526c29b5e)

### PR 특이 사항
- #216 에서 발생한 버그를 수정했습니다
